### PR TITLE
Fix compatibility with Scratch runtime

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -372,7 +372,7 @@ where T: Write + Seek
         self.warp(proc.warp)?;
         self.end_obj()?;
         self.end_obj()?;
-        self.stmts(s, d, &proc.body, next_id, Some(next_id))
+        self.stmts(s, d, &proc.body, next_id, Some(this_id))
     }
 
     fn event(&mut self, s: S, d: D, event: &Event) -> Result<()> {
@@ -422,7 +422,7 @@ where T: Write + Seek
                 self.end_obj()?;
             }
         }
-        self.stmts(s, d, &event.body, next_id, Some(next_id))
+        self.stmts(s, d, &event.body, next_id, Some(this_id))
     }
 
     fn stmts(

--- a/src/codegen/node.rs
+++ b/src/codegen/node.rs
@@ -66,15 +66,23 @@ where T: Write + Seek
         write!(self, r#"{}:{{"opcode":"{}""#, node.this_id, node.opcode)?;
         if let Some(next_id) = node.next_id {
             write!(self, r#","next":{next_id}"#)?;
+        } else {
+            write!(self, r#","next":null"#)?;
         }
         if let Some(parent_id) = node.parent_id {
             write!(self, r#","parent":{parent_id}"#)?;
+        } else {
+            write!(self, r#","parent":null"#)?;
         }
         if node.top_level {
             self.write_all(br#","topLevel":true"#)?;
+        } else {
+            self.write_all(br#","topLevel":false"#)?;
         }
         if node.shadow {
             self.write_all(br#","shadow":true"#)?;
+        } else {
+            self.write_all(br#","shadow":false"#)?;
         }
         Ok(())
     }


### PR DESCRIPTION
There were two problems I identified when running a project generated by Goboscript using the vanilla Scratch runtime:
1. Code running from a procedure call or an event crashes the website.
2. Say and wait blocks did not work properly. I don't really know why.

This pull request fixes those issues.