### PR TITLE
add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /playground
 node_modules
 site
+/result
 # Added by goreleaser init:
 dist/
 .intentionally-empty-file.o

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
         "./Cargo.toml",
         "./Cargo.toml"
     ],
-    "rust-analyzer.showUnlinkedFileNotification": false
+    "rust-analyzer.showUnlinkedFileNotification": false,
+    "nixEnvSelector.nixFile": "${workspaceRoot}/flake.nix"
 }

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,18 @@
+{ lib, rustPlatform }:
+
+rustPlatform.buildRustPackage {
+  pname = "goboscript";
+  version = "3.0.0";
+
+  src = ./.;
+
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+  };
+
+  meta = {
+    description = "Scratch compiler";
+    homepage = "https://github.com/aspizu/goboscript";
+    license = lib.licenses.mit;
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1741513245,
+        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "Scratch compiler";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = inputs@{ self, nixpkgs, flake-utils, ... }:
+  flake-utils.lib.eachSystem [ "x86_64-linux" ] (system: let
+    pkgs = nixpkgs.legacyPackages.${system};
+  in rec {
+    packages.goboscript = pkgs.callPackage ./default.nix { };
+
+    legacyPackages = packages;
+
+    defaultPackage = packages.goboscript;
+
+    devShell = pkgs.mkShell {
+      buildInputs = with pkgs; [ cargo rustc git ];
+    };
+  });
+}


### PR DESCRIPTION
adds:
 - a flake that:
   - has a devshell with the packages:
     - `cargo`
     - `rustc`
     - `git`
   - can build goboscript from `default.nix`
 - a vscode settings entry that lists the added flake as the desired nix environment
 - a gitignore entry for the `nix build` output directory (`./result`)
 - a `default.nix` file that contains the goboscript package