### PR TITLE
Add the of expression

### DIFF
--- a/editors/code/syntaxes/goboscript.tmGrammar.yml
+++ b/editors/code/syntaxes/goboscript.tmGrammar.yml
@@ -33,7 +33,7 @@ patterns:
   - name: keyword.control
     match: "\\b(if|else|elif|until|forever|repeat|delete|at|add|to|insert|true|false|as|struct|enum|return)\\b"
   - name: keyword
-    match: "\\b(error|warn|breakpoint|local|not|and|or|in|length|round|abs|floor|ceil|sqrt|sin|cos|tan|asin|acos|atan|ln|log|antiln|antilog)\\b"
+    match: "\\b(error|warn|breakpoint|local|not|and|or|of|in|length|round|abs|floor|ceil|sqrt|sin|cos|tan|asin|acos|atan|ln|log|antiln|antilog)\\b"
   - name: support.function.builtin
     match: "\\bset_layer_order\\b"
   - name: support.function.builtin

--- a/editors/notepad++/goboscript.udl.xml
+++ b/editors/notepad++/goboscript.udl.xml
@@ -14,7 +14,7 @@
             <Keywords name="Numbers, suffix2"></Keywords>
             <Keywords name="Numbers, range"></Keywords>
             <Keywords name="Operators1">== ++ -- += -= *= /= //= %= &amp;= != &lt; &gt; &lt;= &gt;= &amp; + - * / // ; ( ) { } [ ] , |&gt;</Keywords>
-            <Keywords name="Operators2">not in length round abs floor ceil sqrt sin cos tan asin acos atan ln log antiln antilog %</Keywords>
+            <Keywords name="Operators2">not in length round abs floor ceil sqrt sin cos tan asin acos atan ln log antiln antilog % of</Keywords>
             <Keywords name="Folders in code1, open">{</Keywords>
             <Keywords name="Folders in code1, middle"></Keywords>
             <Keywords name="Folders in code1, close">}</Keywords>

--- a/editors/sublime/goboscript.sublime-syntax
+++ b/editors/sublime/goboscript.sublime-syntax
@@ -25,7 +25,7 @@ contexts:
       match: "\\b(if|else|elif|until|forever|repeat|delete|at|add|to|insert)\\b"
 
     - scope: keyword
-      match: "\\b(error|warn|breakpoint|local|not|and|or|in|length|round|abs|floor|ceil|sqrt|sin|cos|tan|asin|acos|atan|ln|log|antiln|antilog)\\b"
+      match: "\\b(error|warn|breakpoint|local|not|and|or|of|in|length|round|abs|floor|ceil|sqrt|sin|cos|tan|asin|acos|atan|ln|log|antiln|antilog)\\b"
 
     - scope: support.function.builtin
       match: "\\b(move|turn_left|turn_right|goto_random_position|goto_mouse_pointer|goto|glide|glide_to_random_position|glide_to_mouse_pointer|point_in_direction|point_towards_mouse_pointer|point_towards_random_direction|point_towards|change_x|set_x|change_y|set_y|if_on_edge_bounce|set_rotation_style_left_right|set_rotation_style_do_not_rotate|set_rotation_style_all_around|say|think|switch_costume|next_costume|switch_backdrop|next_backdrop|set_size|change_size|change_color_effect|change_fisheye_effect|change_whirl_effect|change_pixelate_effect|change_mosaic_effect|change_brightness_effect|change_ghost_effect|set_color_effect|set_fisheye_effect|set_whirl_effect|set_pixelate_effect|set_mosaic_effect|set_brightness_effect|set_ghost_effect|clear_graphic_effects|show|hide|goto_front|goto_back|go_forward|go_backward|play_sound_until_done|start_sound|stop_all_sounds|change_pitch_effect|change_pan_effect|set_pitch_effect|set_pan_effect|change_volume|set_volume|clear_sound_effects|broadcast|broadcast_and_wait|wait|wait_until|stop_all|stop_this_script|stop_other_scripts|delete_this_clone|clone|ask|set_drag_mode_draggable|set_drag_mode_not_draggable|reset_timer|erase_all|stamp|pen_down|pen_up|set_pen_color|change_pen_size|set_pen_size|rest|set_tempo|change_tempo)\\b"

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -53,6 +53,11 @@ pub enum Expr {
         span: Span,
         fields: Vec<StructLiteralField>,
     },
+    Of {
+        span: Span,
+        property: SmolStr,
+        object: SmolStr,
+    },
 }
 
 impl Expr {
@@ -67,6 +72,7 @@ impl Expr {
             Self::UnOp { span, .. } => span.clone(),
             Self::BinOp { span, .. } => span.clone(),
             Self::StructLiteral { span, .. } => span.clone(),
+            Self::Of { span, .. } => span.clone(),
         }
     }
 }

--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -425,4 +425,32 @@ where T: Write + Seek
         eprintln!("attempted to codegen Expr::Dot lhs = {lhs:#?}, rhs = {rhs:#?}");
         Ok(())
     }
+
+    pub fn property_of(
+        &mut self,
+        s: S,
+        d: D,
+        expr: &Expr,
+        this_id: NodeID,
+        parent_id: NodeID,
+        property: &SmolStr,
+        object: &SmolStr,
+    ) -> io::Result<()> {
+        let menu_id = self.id.new_id();
+        self.begin_node(
+            Node::new("sensing_of_object_menu", menu_id)
+            .parent_id(this_id)
+            .shadow(true)
+        )?;
+        self.single_field("OBJECT", object)?;
+        self.end_obj()?; // node
+
+        self.begin_node(Node::new("sensing_of", this_id).parent_id(parent_id))?;
+        self.begin_inputs()?;
+        self.input(s, d, "OBJECT", expr, menu_id)?;
+        self.end_obj()?; // inputs
+        self.single_field("PROPERTY", property)?;
+        self.end_obj()?; // node
+        Ok(())
+    }
 }

--- a/src/codegen/input.rs
+++ b/src/codegen/input.rs
@@ -148,7 +148,9 @@ where T: Write + Seek
         node_id: NodeID,
         shadow_id: Option<NodeID>,
     ) -> io::Result<()> {
-        if ["CONDITION", "CONDITION2"].contains(&input_name) {
+        if ["OBJECT"].contains(&input_name) {
+            return write!(self, "[1,{node_id}]");
+        } else if ["CONDITION", "CONDITION2"].contains(&input_name) {
             return write!(self, "[2,{node_id}]");
         }
         write!(self, "[3,{node_id},")?;

--- a/src/codegen/sb3.rs
+++ b/src/codegen/sb3.rs
@@ -1196,6 +1196,9 @@ where T: Write + Seek
             Expr::Dot { lhs, rhs, rhs_span } => {
                 self.expr_dot(s, d, this_id, parent_id, lhs, rhs, rhs_span.clone())
             }
+            Expr::Of { property, span, object} => {
+                self.property_of(s, d, expr, this_id, parent_id, property, object)
+            }
         }
     }
 }

--- a/src/parser/grammar.lalrpop
+++ b/src/parser/grammar.lalrpop
@@ -510,6 +510,7 @@ Term: Expr = {
         }
     },
     <l:@L> <term:Term> "[" <index:Expr> "]" <r:@R> => BinOp::Of.to_expr(l..r, term, index),
+    <l:@L> <property:NAME> OF <object:NAME> <r:@R> => Expr::Of { span: l..r, property, object },
     <lhs:Term> "." <l:@L> <rhs:NAME> <r:@R> => {
         Expr::Dot { lhs: Box::new(lhs), rhs, rhs_span: l..r }
     }

--- a/src/visitor/pass1.rs
+++ b/src/visitor/pass1.rs
@@ -314,6 +314,9 @@ fn visit_expr(expr: &mut Expr, before: &mut Vec<Stmt>, s: &mut S) {
             }
             None
         }
+        Expr::Of { span: _, property: _, object: _ } => {
+            None
+        },
     };
     if let Some(replace) = replace {
         *expr = replace;

--- a/src/visitor/pass2.rs
+++ b/src/visitor/pass2.rs
@@ -353,7 +353,8 @@ fn visit_expr(expr: &mut Expr, s: S, d: D, coerce_condition: bool) {
             for field in fields {
                 visit_expr(&mut field.value, s, d, false);
             }
-        }
+        },
+        Expr::Of { span: _, property: _, object: _ } => {},
     }
     transformations::apply(expr, transformations::minus);
     transformations::apply(expr, transformations::less_than_equal);

--- a/tests/sensing/main.gs
+++ b/tests/sensing/main.gs
@@ -28,4 +28,5 @@ onflag {
     say current_second();
     say days_since_2000();
     say username();
+    say direction of foo;
 }


### PR DESCRIPTION
This PR adds the `of` expression, representing the `([property v] of [something v])` sensing reporter. This allows other sprites to read (but not write) private variables of another sprite, along with some other attributes like direction and costume names.

Here's how one would use this:
```
# foo.gs
var something = "123";
```
```
# bar.gs
onflag {
    say something of foo; # says 123
}
```

Things like verifying names and documentation is yet to be implemented. 