### PR TITLE
fix: use serde to serialize variable defaults

### DIFF
--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -86,6 +86,13 @@ impl Value {
             Value::String(string) => string.clone(),
         }
     }
+    
+    pub fn to_js_string(&self) -> SmolStr {
+        match self {
+            Value::String(string) => arcstr::format!("\"{}\"", string),
+            _ => self.to_string(),
+        }
+    }
 
     pub fn is_integer(&self) -> bool {
         match self {

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -86,13 +86,6 @@ impl Value {
             Value::String(string) => string.clone(),
         }
     }
-    
-    pub fn to_js_string(&self) -> SmolStr {
-        match self {
-            Value::String(string) => arcstr::format!("\"{}\"", string),
-            _ => self.to_string(),
-        }
-    }
 
     pub fn is_integer(&self) -> bool {
         match self {

--- a/src/codegen/sb3.rs
+++ b/src/codegen/sb3.rs
@@ -693,17 +693,25 @@ where T: Write + Seek
     ) -> io::Result<()> {
         write_comma_io(&mut self.zip, comma)?;
         let default = match default {
-            Some((value, _)) => value.to_js_string(),
+            Some((value, _)) => value.to_string(),
             None => arcstr::literal!("0"),
         };
         if is_cloud {
             write!(
                 self,
-                "\"{}\":[\"\u{2601} {}\",{default},true]",
-                var_name, var_name
+                "\"{}\":[\"\u{2601} {}\",{},true]",
+                var_name,
+                var_name,
+                json!(*default)
             )
         } else {
-            write!(self, "\"{}\":[\"{}\",{default}]", var_name, var_name)
+            write!(
+                self,
+                "\"{}\":[\"{}\",{}]",
+                var_name,
+                var_name,
+                json!(*default)
+            )
         }
     }
 

--- a/src/codegen/sb3.rs
+++ b/src/codegen/sb3.rs
@@ -693,7 +693,7 @@ where T: Write + Seek
     ) -> io::Result<()> {
         write_comma_io(&mut self.zip, comma)?;
         let default = match default {
-            Some((value, _)) => value.to_string(),
+            Some((value, _)) => value.to_js_string(),
             None => arcstr::literal!("0"),
         };
         if is_cloud {


### PR DESCRIPTION
If you initialize a variable with a string constant, the string is written to `project.json` without quotes.

```
costumes "blank.svg";

var my_string = "Hello";

onflag {
    say my_string;
}
```

Before:
```
"variables":{"my_string":["my_string",Hello]}
```

After fix:
```
"variables": {
    "my_string": [
        "my_string",
        "Hello"
    ]
},
```