### PR TITLE
More diagnostics fixing

### DIFF
--- a/src/ast/references.rs
+++ b/src/ast/references.rs
@@ -11,6 +11,7 @@ pub struct References {
     pub procs: FxHashSet<SmolStr>,
     pub funcs: FxHashSet<SmolStr>,
     pub names: FxHashSet<NameReference>,
+    pub generated_names: FxHashSet<NameReference>,
     pub structs: FxHashSet<SmolStr>,
     pub args: FxHashSet<NameReference>,
 }

--- a/src/diagnostic/diagnostic_kind.rs
+++ b/src/diagnostic/diagnostic_kind.rs
@@ -180,7 +180,7 @@ impl DiagnosticKind {
             DiagnosticKind::UnusedProc(name) => format!("unused procedure {name}"),
             DiagnosticKind::UnusedFunc(name) => format!("unused function {name}"),
             DiagnosticKind::UnusedArg(name) => format!("unused argument {name}"),
-            DiagnosticKind::UnusedStructField(name) => format!("unused struct field {name}"),
+            DiagnosticKind::UnusedStructField(name) => format!("unused struct field {name} (never read)"),
             DiagnosticKind::UnusedEnumVariant(name) => format!("unused enum variant {name}"),
             DiagnosticKind::NotStruct => "not a struct".to_string(),
             DiagnosticKind::StructDoesNotHaveField {

--- a/src/visitor/pass2.rs
+++ b/src/visitor/pass2.rs
@@ -62,6 +62,13 @@ impl S<'_> {
                 .and_then(|global_structs| global_structs.get(name))
         })
     }
+
+    pub fn get_enum(&self, name: &str) -> Option<&Enum> {
+        self.enums.get(name).or_else(|| {
+            self.global_enums
+                .and_then(|global_enums| global_enums.get(name))
+        })
+    }
 }
 
 pub fn visit_project(
@@ -376,6 +383,7 @@ fn visit_expr(expr: &mut Expr, s: S, d: D) {
     transformations::apply(expr, transformations::bin_op);
     transformations::apply(expr, transformations::un_op);
     transformations::apply(expr, |expr| transformations::variable_field_access(expr, s));
+    transformations::apply(expr, |expr| transformations::enum_field_access(expr, s));
     transformations::apply(expr, |expr| transformations::arg_field_access(expr, s));
     transformations::apply(expr, |expr| transformations::list_field_access(expr, s));
     transformations::apply(expr, |expr| {

--- a/src/visitor/pass3.rs
+++ b/src/visitor/pass3.rs
@@ -162,7 +162,6 @@ fn visit_stmt(stmt: &Stmt, s: &mut S) {
 }
 
 fn visit_expr(expr: &Expr, s: &mut S) {
-    dbg!(expr);
     match expr {
         Expr::Value { value: _, span: _ } => {}
         Expr::Name(name) => {

--- a/src/visitor/pass3.rs
+++ b/src/visitor/pass3.rs
@@ -162,17 +162,21 @@ fn visit_stmt(stmt: &Stmt, s: &mut S) {
 }
 
 fn visit_expr(expr: &Expr, s: &mut S) {
+    dbg!(expr);
     match expr {
         Expr::Value { value: _, span: _ } => {}
         Expr::Name(name) => {
-            if !name.is_generated() {
-                s.references.names.insert(NameReference {
-                    name: name.basename().clone(),
-                    field: name.fieldname().cloned(),
-                    proc: s.proc.map(|p| p.name.clone()),
-                    func: s.func.map(|f| f.name.clone()),
-                });
-            }
+            let references = if name.is_generated() {
+                &mut s.references.generated_names
+            } else {
+                &mut s.references.names
+            };
+            references.insert(NameReference {
+                name: name.basename().clone(),
+                field: name.fieldname().cloned(),
+                proc: s.proc.map(|p| p.name.clone()),
+                func: s.func.map(|f| f.name.clone()),
+            });
         }
         Expr::Dot {
             lhs,

--- a/src/visitor/pass4.rs
+++ b/src/visitor/pass4.rs
@@ -225,6 +225,7 @@ fn resolve_references(
             continue;
         }
         if let Some(enum_) = scope.enums.get_mut(&refr.name) {
+            enum_.is_used = true;
             if let Some(variant) = refr
                 .field
                 .as_ref()

--- a/src/visitor/pass4.rs
+++ b/src/visitor/pass4.rs
@@ -36,6 +36,7 @@ impl Scope<'_> {
         let Some(struct_) = structs.get_mut(type_name) else {
             return;
         };
+        struct_.is_used = true;
         let Some(f) = struct_.fields.iter_mut().find(|f| &f.name == field) else {
             return;
         };
@@ -234,6 +235,13 @@ fn resolve_references(
                 variant.is_used = true;
                 continue;
             }
+        }
+    }
+    for refr in &references.generated_names {
+        // if the only use of a struct is to construct it using a struct literal, the names will be
+        // generated, so mark as used here.
+        if let Some(struct_) = scope.structs.get_mut(&refr.name) {
+            struct_.is_used = true;
         }
     }
     for struct_name in &references.structs {

--- a/src/visitor/transformations.rs
+++ b/src/visitor/transformations.rs
@@ -134,7 +134,10 @@ pub fn variable_field_access(expr: &Expr, s: S) -> Option<Expr> {
 }
 
 pub fn enum_field_access(expr: &Expr, s: S) -> Option<Expr> {
-    let Expr::Name(name) = expr else {
+    let Expr::Dot { lhs, rhs, rhs_span } = expr else {
+        return None;
+    };
+    let Expr::Name(name) = (**lhs).clone() else {
         return None;
     };
     if name.fieldname().is_some() {
@@ -143,26 +146,13 @@ pub fn enum_field_access(expr: &Expr, s: S) -> Option<Expr> {
     let basename = name.basename();
     let span = name.span();
     let enum_ = s.get_enum(basename)?;
-    Some(Expr::StructLiteral {
-        name: enum_.name.clone(),
-        span: enum_.span.clone(),
-        fields: enum_
-            .variants
-            .iter()
-            .map(|variant| StructLiteralField {
-                name: variant.name.clone(),
-                span: variant.span.clone(),
-                value: Expr::Name(Name::DotName {
-                    lhs: enum_.name.clone(),
-                    lhs_span: span.clone(),
-                    rhs: variant.name.clone(),
-                    rhs_span: variant.span.clone(),
-                    is_generated: true,
-                })
-                .into(),
-            })
-            .collect(),
-    })
+    Some(Expr::Name(Name::DotName {
+        lhs: enum_.name.clone(),
+        lhs_span: span.clone(),
+        rhs: rhs.clone(),
+        rhs_span: rhs_span.clone(),
+        is_generated: false, // this is technically generated but we want diagnostics to be emitted
+    }))
 }
 
 pub fn arg_field_access(expr: &Expr, s: S) -> Option<Expr> {


### PR DESCRIPTION
This pull request fixes a couple of bugs to do with unused item diagnostics.

- unused enums (c3fec40cbce2c45a9147bc72cc896ac2157e47c0) - a simple fix.
- unused structs (af1b1368c6ec642cec4cf0d658b0c88cbd7d2e29) - structs are now marked as used if you read any of their fields; they are also marked as used if they are ever constructed using a struct literal. If "use" actually means reading, this can be changed and the wording modified; I also changed the wording of the unused struct field diagnostic to specify that this means reading that field.
- unused enum variants (c1d6edce46cf055e4c2f4ca7d94a10cf8ec989aa) - to do this I changed the way enums are represented in the AST: they are now transformed, like struct fields, to a `DotName` in pass 2. This makes things significantly easier, although does make some bits of code that expect a struct a bit messier. I think it is an acceptable trade off.

Following these changes, the following code now compiles without warnings:
```
costumes "blank.svg";
enum Cat {
    dog
}
struct Foo {
    bar
}
onflag {
    Foo foo = Foo { bar: 2 };
    say foo.bar;
    say Cat.dog;
}
```

I am not sure whether any other parts of the compiler depend upon enum variant accesses being in a `Dot` rather than a `Name` - in particular I suspect that const expression evaluation may be affected. However I have no idea how that works so I'll need to Read The Docs a bit more before I look into that. Some testing from someone who actually understands goboscript would be nice.