### PR TITLE
Add validation for invalid costume and backdrop names

### DIFF
--- a/src/diagnostic/diagnostic_kind.rs
+++ b/src/diagnostic/diagnostic_kind.rs
@@ -40,6 +40,8 @@ pub enum DiagnosticKind {
     UnrecognizedEnumVariant(SmolStr),
     UnrecognizedStandardLibraryHeader,
     NoCostumes,
+    InvalidCostumeName(SmolStr),
+    InvalidBackdropName(SmolStr),
     BlockArgsCountMismatch {
         block: Block,
         given: usize,
@@ -133,6 +135,12 @@ impl DiagnosticKind {
                 "unrecognized standard library header".to_string()
             }
             DiagnosticKind::NoCostumes => "no costumes".to_string(),
+            DiagnosticKind::InvalidCostumeName(name) => {
+                format!("costume '{}' does not exist", name)
+            }
+            DiagnosticKind::InvalidBackdropName(name) => {
+                format!("backdrop '{}' does not exist", name)
+            }
             DiagnosticKind::BlockArgsCountMismatch { block, given } => {
                 format!(
                     "block {:?} expects {} arguments, but {} were given",
@@ -207,6 +215,20 @@ impl DiagnosticKind {
             DiagnosticKind::NoCostumes => {
                 Some("if this is a header, move it inside a directory such as `lib/`".to_string())
             }
+            DiagnosticKind::InvalidCostumeName(name) => {
+                if name.contains('.') {
+                    Some("costume names should not include file extensions - they are automatically derived from the file name without extension".to_string())
+                } else {
+                    None
+                }
+            }
+            DiagnosticKind::InvalidBackdropName(name) => {
+                if name.contains('.') {
+                    Some("backdrop names should not include file extensions - they are automatically derived from the file name without extension".to_string())
+                } else {
+                    None
+                }
+            }
             DiagnosticKind::UnrecognizedToken(token, expected) => match token {
                 Token::FloorDiv => Some("Use # for comments".to_owned()),
                 Token::Var => Some("var should only be used at top-level.".to_owned()),
@@ -264,7 +286,9 @@ impl From<&DiagnosticKind> for Level {
             | DiagnosticKind::NotStruct
             | DiagnosticKind::MissingField { .. }
             | DiagnosticKind::StructDoesNotHaveField { .. }
-            | DiagnosticKind::EmptyStruct(_) => Level::Error,
+            | DiagnosticKind::EmptyStruct(_)
+            | DiagnosticKind::InvalidCostumeName(_)
+            | DiagnosticKind::InvalidBackdropName(_) => Level::Error,
 
             | DiagnosticKind::FollowedByUnreachableCode
             | DiagnosticKind::UnrecognizedKey(_)


### PR DESCRIPTION
## Summary
- Adds compile-time validation for `switch_costume` and `switch_backdrop` blocks
- Warns when costume/backdrop names don't exist, preventing runtime errors
- Provides helpful guidance when file extensions are incorrectly included

## Changes
- Added `InvalidCostumeName` and `InvalidBackdropName` diagnostic types
- Enhanced `switch_costume` validation against sprite's costume list  
- Enhanced `switch_backdrop` validation against stage's costume list (backdrops)
- Cross-sprite backdrop validation: properly accesses stage from any sprite context
- Helpful error messages with file extension guidance

## Test plan
- [x] Validates invalid costume names in `switch_costume` blocks
- [x] Validates invalid backdrop names in `switch_backdrop` blocks  
- [x] Shows helpful error messages with file extension guidance
- [x] Works from both stage and non-stage sprites
- [x] Existing tests pass with new validation errors caught

## Example Output
```
error: costume 'dango' does not exist
--> main.gs:8:20
|
8 |     switch_costume "dango";
  |                    ^^^^^^^

error: backdrop 'dango' does not exist  
--> main.gs:11:21
|
11 |     switch_backdrop "dango";
   |                     ^^^^^^^
```

Closes #156

🤖 Generated with [Claude Code](https://claude.ai/code)