### PR TITLE
docs: add link to standard library repository

### DIFF
--- a/docs/standard-library.md
+++ b/docs/standard-library.md
@@ -3,6 +3,8 @@
 The standard library is a collection of useful procedures, functions and macros that
 can be used in any goboscript project.
 
+**Repository:** <https://github.com/goboscript/std>
+
 ## Standard library headers
 
 Include a header using the `%include` directive.


### PR DESCRIPTION
Fixes #122 - adds missing link to https://github.com/goboscript/std in the standard library documentation page