### PR TITLE
Fix panics caused by include

### DIFF
--- a/src/translation_unit.rs
+++ b/src/translation_unit.rs
@@ -220,6 +220,10 @@ impl TranslationUnit {
         begin: usize,
         stdlib: &StandardLibrary,
     ) -> Result<(), Diagnostic> {
+        while self.includes[self.current_include].unit_range.end < begin {
+            self.current_include += 1;
+        }
+
         let parent = self.includes[self.current_include].path.parent().unwrap();
         let mut fs = fs.borrow_mut();
         let mut buffer = vec![];

--- a/src/translation_unit.rs
+++ b/src/translation_unit.rs
@@ -249,6 +249,9 @@ impl TranslationUnit {
             span: path_span,
         })?;
         file.read_to_end(&mut buffer).unwrap();
+        if buffer.last().is_none_or(|&c| c != b'\n') {
+            buffer.push(b'\n');
+        }
         self.text.splice(begin..begin, buffer.iter().cloned());
 
         // split current include into two parts


### PR DESCRIPTION
This fixes #197 (and #192) by updating `self.current_include` in to point to the correct include if it's pointing at an old one.

I also fixed #196 by adding a newline to included files missing one at the end (in the same way as it is done for the main file)

I tested it on some of the examples that were broken and it works.