### PR TITLE
Fix until loop function evaluation bug

### DIFF
--- a/src/visitor/pass1.rs
+++ b/src/visitor/pass1.rs
@@ -93,8 +93,10 @@ fn visit_stmt(stmt: &mut Stmt, s: &mut S) -> Vec<Stmt> {
             visit_stmts(else_body, s);
         }
         Stmt::Until { cond, body } => {
-            visit_expr(cond, &mut before, s);
+            let mut cond_callsites = vec![];
+            visit_expr(cond, &mut cond_callsites, s);
             visit_stmts(body, s);
+            body.extend(cond_callsites);
         }
         Stmt::SetVar {
             name: _,


### PR DESCRIPTION
Function calls in until loop conditions are now evaluated every iteration instead of only once before the loop starts. This is achieved by collecting the callsites from the condition separately and appending them to the end of the loop body, ensuring they are re-evaluated each iteration.