### PR TITLE
fix: emit errors for unrecognized and missing sprites in layers config

### DIFF
--- a/src/codegen/sb3.rs
+++ b/src/codegen/sb3.rs
@@ -10,6 +10,7 @@ use std::{
     rc::Rc,
 };
 
+use anyhow::bail;
 use fxhash::{
     FxHashMap,
     FxHashSet,
@@ -429,22 +430,8 @@ where T: Write + Seek
         config: &Config,
         stage_diagnostics: D,
         sprites_diagnostics: &mut FxHashMap<SmolStr, SpriteDiagnostics>,
-    ) -> io::Result<()> {
-        let mut layers: FxHashMap<SmolStr, usize> = Default::default();
-        let mut keys: Vec<_> = project.sprites.keys().collect();
-        keys.sort();
-        let mut i = 1;
-        for key in keys {
-            layers.insert(key.clone(), i);
-            i += 1;
-        }
-        if let Some(configured) = &config.layers {
-            let mut i = 1;
-            for layer in configured {
-                layers.insert(layer.into(), i);
-                i += 1;
-            }
-        }
+    ) -> anyhow::Result<()> {
+        let layers = compute_layers(project, config)?;
         let broadcasts: FxHashSet<_> = project
             .stage
             .events
@@ -1433,4 +1420,51 @@ where T: Write + Seek
             } => self.property(s, d, this_id, parent_id, object, property, span),
         }
     }
+}
+
+fn compute_layers(project: &Project, config: &Config) -> anyhow::Result<FxHashMap<SmolStr, usize>> {
+    let mut layers: FxHashMap<SmolStr, usize> = Default::default();
+    let mut keys: Vec<_> = project.sprites.keys().collect();
+    keys.sort();
+    let mut i = 1;
+    for key in keys {
+        layers.insert(key.clone(), i);
+        i += 1;
+    }
+    if let Some(configured) = &config.layers {
+        let mut extra = vec![];
+        for layer in configured {
+            if !project.sprites.contains_key(&**layer) {
+                extra.push(layer.clone());
+            }
+        }
+        let mut missing = vec![];
+        for layer in project.sprites.keys() {
+            if configured
+                .iter()
+                .find(|configured| &**configured == &*layer)
+                .is_none()
+            {
+                missing.push(layer.clone());
+            }
+        }
+        if !extra.is_empty() {
+            bail!(
+                "layers references sprites that do not exist: {}",
+                extra.join(", ")
+            );
+        }
+        if !missing.is_empty() {
+            bail!(
+                "layers does not reference sprites that exist: {}",
+                missing.join(", ")
+            );
+        }
+        let mut i = 1;
+        for layer in configured {
+            layers.insert(layer.into(), i);
+            i += 1;
+        }
+    }
+    Ok(layers)
 }

--- a/src/diagnostic/diagnostic_kind.rs
+++ b/src/diagnostic/diagnostic_kind.rs
@@ -86,8 +86,6 @@ pub enum DiagnosticKind {
         field_name: SmolStr,
     },
     EmptyStruct(SmolStr),
-    UnrecognizedLayerSprite(SmolStr),
-    MissingLayerSprite(SmolStr),
     // Warnings
     FollowedByUnreachableCode,
     UnrecognizedKey(SmolStr),
@@ -227,12 +225,6 @@ impl DiagnosticKind {
                 format!("struct {struct_name} is missing field {field_name}")
             }
             DiagnosticKind::EmptyStruct(name) => format!("struct {name} is empty"),
-            DiagnosticKind::UnrecognizedLayerSprite(name) => {
-                format!("layers references sprite '{name}' which does not exist")
-            }
-            DiagnosticKind::MissingLayerSprite(name) => {
-                format!("sprite '{name}' is not listed in layers")
-            }
         }
     }
 
@@ -394,9 +386,7 @@ impl From<&DiagnosticKind> for Level {
             | DiagnosticKind::InvalidCostumeName(_)
             | DiagnosticKind::DuplicateCostume(_)
             | DiagnosticKind::DuplicateBackdrop(_)
-            | DiagnosticKind::InvalidBackdropName(_)
-            | DiagnosticKind::UnrecognizedLayerSprite(_)
-            | DiagnosticKind::MissingLayerSprite(_) => Level::Error,
+            | DiagnosticKind::InvalidBackdropName(_) => Level::Error,
 
             | DiagnosticKind::FollowedByUnreachableCode
             | DiagnosticKind::UnrecognizedKey(_)


### PR DESCRIPTION
## Summary

Fixes the issue where specifying a non-existent sprite name in `layers` or omitting a sprite from `layers` produced no error.

## Changes

- Added two new `DiagnosticKind` variants:
  - `UnrecognizedLayerSprite`: emitted when a name in `layers` does not correspond to any existing sprite.
  - `MissingLayerSprite`: emitted when an existing sprite is not listed in `layers`.
- Both are `Level::Error`.
- Validation is performed in `assign_layer_orders` and reported on the stage diagnostics.