### PR TITLE
perf(codegen): preload assets in parallel using rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +766,7 @@ dependencies = [
  "md-5",
  "pretty_env_logger",
  "rand 0.9.1",
+ "rayon",
  "reqwest",
  "semver",
  "serde",
@@ -1647,6 +1673,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tsify = { version = "0.5.5", default-features = false, features = ["js"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 inquire = "0.7.5"
 rand = "0.9.1"
+rayon = "1.10"
 
 [build-dependencies]
 lalrpop = "0.22.0"

--- a/src/codegen/assets.rs
+++ b/src/codegen/assets.rs
@@ -38,7 +38,7 @@ pub struct AssetObject {
 pub struct AssetObjectStore {
     store: FxHashMap<SmolStr, AssetObject>,
     fs: Rc<RefCell<dyn VFS>>,
-    input: PathBuf,
+    pub input: PathBuf,
 }
 
 impl AssetObjectStore {
@@ -47,6 +47,43 @@ impl AssetObjectStore {
             store: FxHashMap::default(),
             fs,
             input,
+        }
+    }
+
+    /// Preload a batch of asset paths in parallel (native only).
+    /// Must be called before `load()` for best effect.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn preload(&mut self, paths: &[SmolStr]) {
+        use rayon::prelude::*;
+
+        let input = &self.input;
+        let results: Vec<(SmolStr, AssetObject)> = paths
+            .par_iter()
+            .filter(|path| !self.store.contains_key(*path))
+            .filter_map(|path| {
+                let full_path = input.join(&**path);
+                let content = match std::fs::read(&full_path) {
+                    Ok(c) => c,
+                    Err(_) => return None,
+                };
+                let extension = path
+                    .rsplit_once('.')
+                    .unwrap_or_default()
+                    .1
+                    .to_lowercase();
+                let mut hasher = Md5::new();
+                hasher.update(&content);
+                let hash = format!("{:x}", hasher.finalize());
+                Some((path.clone(), AssetObject {
+                    hash,
+                    content,
+                    extension,
+                }))
+            })
+            .collect();
+
+        for (path, obj) in results {
+            self.store.entry(path).or_insert(obj);
         }
     }
 

--- a/src/codegen/sb3.rs
+++ b/src/codegen/sb3.rs
@@ -404,6 +404,21 @@ where T: Write + Seek
         stage_diagnostics: D,
         sprites_diagnostics: &mut FxHashMap<SmolStr, SpriteDiagnostics>,
     ) -> anyhow::Result<()> {
+        // Preload all assets in parallel before sequential zip writing.
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let mut all_asset_paths: Vec<crate::misc::SmolStr> = project
+                .stage
+                .costumes
+                .iter()
+                .chain(&project.stage.sounds)
+                .chain(project.sprites.values().flat_map(|s| s.costumes.iter().chain(&s.sounds)))
+                .map(|a| a.path.clone())
+                .collect();
+            all_asset_paths.sort_unstable();
+            all_asset_paths.dedup();
+            self.asset_object_store.preload(&all_asset_paths);
+        }
         let layers = compute_layers(project, config)?;
         let broadcasts: FxHashSet<_> = project
             .stage


### PR DESCRIPTION
## Summary

Collect all unique asset paths (costumes + sounds) from the entire project upfront, before zip writing begins, and read + MD5-hash them concurrently via `rayon::par_iter()`.

Subsequent `load()` calls during codegen just hit the pre-populated cache with zero I/O or hashing cost.

## Changes

- `Cargo.toml`: add `rayon` as a native-only dependency (excluded from WASM targets)
- `src/codegen/assets.rs`: add `AssetObjectStore::preload()` method (cfg non-wasm32) that parallelises file reads and MD5 hashing
- `src/codegen/sb3.rs`: call `preload()` at the start of `Sb3::project()` with all deduplicated asset paths

## Effect

On projects with many assets the wall-clock compile time is reduced proportionally to the number of CPU cores available, since file I/O and hashing previously ran serially.