### PR TITLE
fix: apply transformations to exprs in events

### DIFF
--- a/src/visitor/pass2.rs
+++ b/src/visitor/pass2.rs
@@ -135,6 +135,28 @@ fn visit_sprite(sprite: &mut Sprite, stage: Option<&Sprite>, d: D) {
             true,
         );
     }
+
+    visit_events(
+        &mut sprite.events,
+        S {
+            proc_args: &sprite.proc_args,
+            func_args: &sprite.func_args,
+            args: None,
+            local_vars: None,
+            vars: &sprite.vars,
+            lists: &sprite.lists,
+            enums: &sprite.enums,
+            structs: &sprite.structs,
+            procs: &sprite.procs,
+            funcs: &sprite.funcs,
+            global_vars: stage.map(|stage| &stage.vars),
+            global_lists: stage.map(|stage| &stage.lists),
+            global_enums: stage.map(|stage| &stage.enums),
+            global_structs: stage.map(|stage| &stage.structs),
+        },
+        d,
+    );
+
     for event in &mut sprite.events {
         visit_stmts(
             &mut event.body,
@@ -187,6 +209,21 @@ fn visit_sprite(sprite: &mut Sprite, stage: Option<&Sprite>, d: D) {
         .collect();
     for (name, span, mut fields) in struct_literals {
         const_struct_literal(s, d, &name, &span, &mut fields);
+    }
+}
+
+fn visit_events(events: &mut Vec<Event>, s: S, d: D) {
+    for event in &mut *events {
+        visit_event(event, s, d);
+    }
+}
+
+fn visit_event(event: &mut Event, s: S, d: D) {
+    match &mut event.kind {
+        EventKind::OnLoudnessGt { value } | EventKind::OnTimerGt { value } => {
+            visit_expr(value.as_mut(), s, d);
+        }
+        _ => { /* no exprs that need to be transformed */ }
     }
 }
 


### PR DESCRIPTION
Fixes #285

So far constant-folding was only applied to expressions appearing in statements. However, the OnLoudnessGt and OnTimerGt event types also contain expressions.

In case of negative number literals this resulted in a crash when generating the Scratch code, since such numbers are represented as `Unop(Minus, 2)` in the Goboscript AST whereas they are direct literals `-2` in Scratch and thus no opcode for Minus exists.

---

I am unsure if this fix is complete or if the event-exprs should also be visited in some of the other passes. At least for the minimal example from the issue it now works.