### PR TITLE
feat(wasm): add TypeScript type declarations for Span, Sprite, FxHashMap

### DIFF
--- a/src/translation_unit.rs
+++ b/src/translation_unit.rs
@@ -35,9 +35,9 @@ pub enum Owner {
 /// A section of a source file that is included in the translation unit.
 /// This may be a section of the source file, or the entire source file.
 pub struct Include {
-    /// The range that the source code of the include is in the translation unit.
+    /// The range that the source code of to include is in the translation unit.
     pub unit_range: Span,
-    // The range that the source code of the include is in the source file.
+    /// The range that the source code of to include is in the source file.
     pub source_range: Span,
     pub path: PathBuf,
     pub owner: Owner,

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -30,6 +30,18 @@ use crate::{
     vfs::MemFS,
 };
 
+#[wasm_bindgen(typescript_custom_section)]
+const TS_APPEND_CONTENT: &'static str = "
+export interface Span {
+    start: number
+    end: number
+}
+
+type Sprite = object
+
+type FxHashMap<K, V> = Map<K, V>
+";
+
 #[derive(Tsify, Serialize, Deserialize)]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct Build {


### PR DESCRIPTION
  tsify can't auto-generate types for external/opaque types, so manual
  typescript_custom_section fills the gaps for WASM consumers.