### PR TITLE
feat(wasm): derive Tsify on all AST and block types

### DIFF
--- a/gdsl.py
+++ b/gdsl.py
@@ -186,6 +186,7 @@ un_ops, bin_ops, blocks, reporters = parse()
 
 f = open("src/blocks.rs", "w")
 f.write("""
+use tsify::Tsify;
 use serde::{Deserialize, Serialize};
 pub struct Menu {
     pub input: &'static str,
@@ -194,7 +195,7 @@ pub struct Menu {
     pub field: &'static str,
 }
 """)
-f.write("#[derive(Debug, Copy, Clone, Serialize, Deserialize)]\npub enum UnOp {")
+f.write("#[derive(Tsify, Debug, Copy, Clone, Serialize, Deserialize)]\npub enum UnOp {")
 for un_op in un_ops:
     f.write(f"{un_op},")
 f.write("}\n\n")
@@ -232,7 +233,7 @@ f.write("_ => unreachable!()")
 f.write("}")
 f.write("}")
 f.write("}\n\n")
-f.write("#[derive(Debug, Copy, Clone, Serialize, Deserialize)]\npub enum BinOp {")
+f.write("#[derive(Tsify, Debug, Copy, Clone, Serialize, Deserialize)]\npub enum BinOp {")
 for bin_op in bin_ops:
     f.write(f"{bin_op},")
 f.write("}\n\n")
@@ -269,7 +270,7 @@ f.write("}")
 
 def write_blocks(typename: str, blocks: dict[str, Block | list[Block]]):
     f.write(
-        f"#[derive(Debug, Copy, Clone, Serialize, Deserialize)]\npub enum {typename} {{"
+        f"#[derive(Tsify, Debug, Copy, Clone, Serialize, Deserialize)]\npub enum {typename} {{"
     )
     for variant, block in blocks.items():
         if isinstance(block, list):

--- a/src/ast/arg.rs
+++ b/src/ast/arg.rs
@@ -3,14 +3,14 @@ use serde::{
     Deserialize,
     Serialize,
 };
-
+use tsify::Tsify;
 use super::{
     type_::Type,
     ConstExpr,
 };
 use crate::misc::SmolStr;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Serialize, Deserialize)]
 pub struct Arg {
     pub name: SmolStr,
     pub span: Span,

--- a/src/ast/asset.rs
+++ b/src/ast/asset.rs
@@ -5,10 +5,10 @@ use serde::{
     Deserialize,
     Serialize,
 };
-
+use tsify::Tsify;
 use crate::misc::SmolStr;
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Tsify, Debug, Serialize, Deserialize, Clone)]
 pub struct Asset {
     pub name: SmolStr,
     pub path: SmolStr,

--- a/src/ast/const_expr.rs
+++ b/src/ast/const_expr.rs
@@ -3,6 +3,7 @@ use serde::{
     Deserialize,
     Serialize,
 };
+use tsify::Tsify;
 
 use super::{
     StructLiteralField,
@@ -16,7 +17,7 @@ use crate::{
     misc::SmolStr,
 };
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Tsify, Debug, Serialize, Deserialize, Clone)]
 pub enum ConstExpr {
     Value {
         value: Value,
@@ -35,7 +36,7 @@ pub enum ConstExpr {
     },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Clone, Serialize, Deserialize)]
 pub struct ConstStructLiteralField {
     pub name: SmolStr,
     pub name_span: Span,

--- a/src/ast/enum_.rs
+++ b/src/ast/enum_.rs
@@ -3,11 +3,11 @@ use serde::{
     Deserialize,
     Serialize,
 };
-
+use tsify::Tsify;
 use super::enum_variant::EnumVariant;
 use crate::misc::SmolStr;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Serialize, Deserialize)]
 pub struct Enum {
     pub name: SmolStr,
     pub span: Span,

--- a/src/ast/enum_variant.rs
+++ b/src/ast/enum_variant.rs
@@ -3,11 +3,11 @@ use serde::{
     Deserialize,
     Serialize,
 };
-
+use tsify::Tsify;
 use super::value::Value;
 use crate::misc::SmolStr;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Serialize, Deserialize)]
 pub struct EnumVariant {
     pub name: SmolStr,
     pub span: Span,

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -4,7 +4,7 @@ use serde::{
     Deserialize,
     Serialize,
 };
-
+use tsify::Tsify;
 use super::{
     value::Value,
     Name,
@@ -19,7 +19,7 @@ use crate::{
     misc::SmolStr,
 };
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Clone, Serialize, Deserialize)]
 pub enum Expr {
     Value {
         value: Value,

--- a/src/ast/func.rs
+++ b/src/ast/func.rs
@@ -3,11 +3,11 @@ use serde::{
     Deserialize,
     Serialize,
 };
-
+use tsify::Tsify;
 use super::Type;
 use crate::misc::SmolStr;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Serialize, Deserialize)]
 pub struct Func {
     pub name: SmolStr,
     pub span: Span,

--- a/src/ast/list.rs
+++ b/src/ast/list.rs
@@ -3,14 +3,14 @@ use serde::{
     Deserialize,
     Serialize,
 };
-
+use tsify::Tsify;
 use super::{
     type_::Type,
     ConstExpr,
 };
 use crate::misc::SmolStr;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Serialize, Deserialize)]
 pub struct List {
     pub name: SmolStr,
     pub span: Span,
@@ -19,7 +19,7 @@ pub struct List {
     pub is_used: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Serialize, Deserialize)]
 pub enum ListDefault {
     Values(Vec<ConstExpr>),
     File { path: SmolStr, span: Span },

--- a/src/ast/name.rs
+++ b/src/ast/name.rs
@@ -3,10 +3,10 @@ use serde::{
     Deserialize,
     Serialize,
 };
-
+use tsify::Tsify;
 use crate::misc::SmolStr;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Clone, Serialize, Deserialize)]
 pub enum Name {
     Name {
         name: SmolStr,

--- a/src/ast/proc.rs
+++ b/src/ast/proc.rs
@@ -3,10 +3,10 @@ use serde::{
     Deserialize,
     Serialize,
 };
-
+use tsify::Tsify;
 use crate::misc::SmolStr;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Serialize, Deserialize)]
 pub struct Proc {
     pub name: SmolStr,
     pub span: Span,

--- a/src/ast/references.rs
+++ b/src/ast/references.rs
@@ -3,10 +3,11 @@ use serde::{
     Deserialize,
     Serialize,
 };
+use tsify::Tsify;
 
 use crate::misc::SmolStr;
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Default, Serialize, Deserialize)]
 pub struct References {
     pub procs: FxHashSet<SmolStr>,
     pub funcs: FxHashSet<SmolStr>,
@@ -16,7 +17,7 @@ pub struct References {
     pub args: FxHashSet<NameReference>,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize, Eq, PartialEq, Hash)]
+#[derive(Tsify, Debug, Default, Serialize, Deserialize, Eq, PartialEq, Hash)]
 pub struct NameReference {
     pub name: SmolStr,
     pub field: Option<SmolStr>,

--- a/src/ast/rotation_style.rs
+++ b/src/ast/rotation_style.rs
@@ -4,8 +4,9 @@ use serde::{
     Deserialize,
     Serialize,
 };
+use tsify::Tsify;
 
-#[derive(Default, Debug, Serialize, Deserialize)]
+#[derive(Tsify, Default, Debug, Serialize, Deserialize)]
 pub enum RotationStyle {
     LeftRight,
     #[default]

--- a/src/ast/sprite.rs
+++ b/src/ast/sprite.rs
@@ -7,7 +7,7 @@ use serde::{
     Deserialize,
     Serialize,
 };
-
+use tsify::Tsify;
 use super::*;
 use crate::{
     diagnostic::{
@@ -17,7 +17,8 @@ use crate::{
     misc::SmolStr,
 };
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Default, Serialize, Deserialize)]
+#[tsify(from_wasm_abi, into_wasm_abi)]
 pub struct Sprite {
     pub costumes: Vec<Asset>,
     pub sounds: Vec<Asset>,

--- a/src/ast/stmt.rs
+++ b/src/ast/stmt.rs
@@ -4,7 +4,7 @@ use serde::{
     Deserialize,
     Serialize,
 };
-
+use tsify::Tsify;
 use super::{
     expr::Expr,
     type_::Type,
@@ -19,7 +19,7 @@ use crate::{
     misc::SmolStr,
 };
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Tsify, Clone, Debug, Serialize, Deserialize)]
 pub enum Stmt {
     Repeat {
         times: Box<Expr>,

--- a/src/ast/struct_.rs
+++ b/src/ast/struct_.rs
@@ -3,14 +3,14 @@ use serde::{
     Deserialize,
     Serialize,
 };
-
+use tsify::Tsify;
 use super::{
     struct_field::StructField,
     ConstExpr,
 };
 use crate::misc::SmolStr;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Serialize, Deserialize)]
 pub struct Struct {
     pub name: SmolStr,
     pub span: Span,

--- a/src/ast/struct_field.rs
+++ b/src/ast/struct_field.rs
@@ -3,11 +3,11 @@ use serde::{
     Deserialize,
     Serialize,
 };
-
+use tsify::Tsify;
 use super::ConstExpr;
 use crate::misc::SmolStr;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Serialize, Deserialize)]
 pub struct StructField {
     pub name: SmolStr,
     pub span: Span,

--- a/src/ast/struct_literal_field.rs
+++ b/src/ast/struct_literal_field.rs
@@ -3,11 +3,12 @@ use serde::{
     Deserialize,
     Serialize,
 };
+use tsify::Tsify;
 
 use super::Expr;
 use crate::misc::SmolStr;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Clone, Serialize, Deserialize)]
 pub struct StructLiteralField {
     pub name: SmolStr,
     pub span: Span,

--- a/src/ast/type_.rs
+++ b/src/ast/type_.rs
@@ -6,10 +6,10 @@ use serde::{
     Deserialize,
     Serialize,
 };
-
+use tsify::Tsify;
 use crate::misc::SmolStr;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Clone, Serialize, Deserialize)]
 pub enum Type {
     Value,
     Struct { name: SmolStr, span: Span },

--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -6,7 +6,6 @@ use serde::{
     Deserialize,
     Serialize,
 };
-
 use crate::misc::SmolStr;
 
 #[derive(Debug, Clone)]

--- a/src/ast/var.rs
+++ b/src/ast/var.rs
@@ -3,14 +3,14 @@ use serde::{
     Deserialize,
     Serialize,
 };
-
+use tsify::Tsify;
 use super::{
     type_::Type,
     ConstExpr,
 };
 use crate::misc::SmolStr;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Serialize, Deserialize)]
 pub struct Var {
     pub name: SmolStr,
     pub span: Span,

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -2,13 +2,14 @@ use serde::{
     Deserialize,
     Serialize,
 };
+use tsify::Tsify;
 pub struct Menu {
     pub input: &'static str,
     pub opcode: &'static str,
     pub default: &'static str,
     pub field: &'static str,
 }
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Copy, Clone, Serialize, Deserialize)]
 pub enum UnOp {
     Not,
     Length,
@@ -101,7 +102,7 @@ impl UnOp {
     }
 }
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Copy, Clone, Serialize, Deserialize)]
 pub enum BinOp {
     Add,
     Sub,
@@ -180,7 +181,7 @@ impl BinOp {
         }
     }
 }
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Copy, Clone, Serialize, Deserialize)]
 pub enum Block {
     Move,
     TurnLeft,
@@ -1097,7 +1098,7 @@ impl Block {
         }
     }
 }
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Copy, Clone, Serialize, Deserialize)]
 pub enum Repr {
     XPosition,
     YPosition,

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -8,11 +8,11 @@ use serde::{
     Deserialize,
     Serialize,
 };
-
+use tsify::Tsify;
 use super::literal::*;
 use crate::misc::SmolStr;
 
-#[derive(Debug, Logos, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Tsify, Debug, Logos, Clone, PartialEq, Serialize, Deserialize)]
 #[logos(skip r"[ \r\t\f]+")]
 #[logos(skip r"#[^\n]*\n")]
 pub enum Token {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -37,9 +37,13 @@ export interface Span {
     end: number
 }
 
-type Sprite = object
+type FxHashMap<K, V> = Map<K, V>;
 
-type FxHashMap<K, V> = Map<K, V>
+type FxHashSet<K> = Set<K>;
+
+type SmolStr = string;
+
+type Value = boolean | number | string;
 ";
 
 #[derive(Tsify, Serialize, Deserialize)]
@@ -51,22 +55,19 @@ pub struct Build {
 }
 
 #[wasm_bindgen]
-pub fn build(fs: JsValue) -> JsValue {
-    let fs: MemFS = serde_wasm_bindgen::from_value(fs).unwrap();
+pub fn build(fs: MemFS) -> Build {
     let fs = Rc::new(RefCell::new(fs));
     let mut file = Vec::new();
     let sb3 = Sb3::new(Cursor::new(&mut file), fs.clone(), "project".into());
     let stdlib = StandardLibrary {
         path: "stdlib".into(),
-        version: Version::new(0, 0, 0),
+        version: Version::new(0, 0,  0),
     };
     let artifact = build_impl(fs, "project".into(), sb3, Some(stdlib)).unwrap();
-    serde_wasm_bindgen::to_value(&Build { file, artifact }).unwrap()
+    Build { file, artifact }
 }
 
 #[wasm_bindgen]
-pub fn diagnostic_to_string(diagnostic: JsValue, sprite: JsValue) -> String {
-    let diagnostic: Diagnostic = serde_wasm_bindgen::from_value(diagnostic).unwrap();
-    let sprite: Sprite = serde_wasm_bindgen::from_value(sprite).unwrap();
+pub fn diagnostic_to_string(diagnostic: Diagnostic, sprite: Sprite) -> String {
     diagnostic.kind.to_string(&sprite)
 }


### PR DESCRIPTION
Enables accurate TypeScript type generation from Rust types directly. Replaces manual serde_wasm_bindgen::from_value/to_value calls in build() and diagnostic_to_string() with Tsify-typed parameters. Adds FxHashSet, SmolStr, and Value TS aliases to supplement FxHashMap.