### PR TITLE
fix: return error instead of panicking when building filesystem root

### DIFF
--- a/src/frontend/build.rs
+++ b/src/frontend/build.rs
@@ -7,6 +7,8 @@ use std::{
     rc::Rc,
 };
 
+use anyhow::bail;
+
 use crate::{
     codegen::{
         build::build_impl,
@@ -19,7 +21,12 @@ use crate::{
 pub fn build(input: Option<PathBuf>, output: Option<PathBuf>) -> anyhow::Result<Artifact> {
     let input = input.unwrap_or_else(|| env::current_dir().unwrap());
     let canonical_input = input.canonicalize()?;
-    let project_name = canonical_input.file_name().unwrap().to_str().unwrap();
+    let Some(project_name) = canonical_input.file_name().and_then(|name| name.to_str()) else {
+        bail!(
+            "{} is not a valid project directory",
+            canonical_input.display()
+        );
+    };
     let output = output.unwrap_or_else(|| input.join(format!("{project_name}.sb3")));
     let fs = Rc::new(RefCell::new(RealFS));
     let sb3 = Sb3::new(
@@ -28,4 +35,19 @@ pub fn build(input: Option<PathBuf>, output: Option<PathBuf>) -> anyhow::Result<
         canonical_input.clone(),
     );
     build_impl(fs, canonical_input, sb3, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::build;
+
+    #[test]
+    fn test_build_root_dir_errors_without_panic() {
+        match build(Some(PathBuf::from("/")), None) {
+            Ok(_) => panic!("building the filesystem root should return an error"),
+            Err(err) => assert!(err.to_string().contains("not a valid project directory")),
+        }
+    }
 }


### PR DESCRIPTION
Fixes #300. `build /` panicked at `canonical_input.file_name().unwrap()` because the filesystem root has no file name. Now it returns a normal build error instead of crashing.