### PR TITLE
Lay out generated Scratch scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1940,6 +1940,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ md-5 = "0.10.6"
 pretty_env_logger = "0.5.0"
 semver = "1.0.25"
 serde = { version = "1.0.210", features = ["derive"] }
-serde_json = "1.0.128"
+serde_json = { version = "1.0.128", features = ["preserve_order"] }
 suggestions = "0.1.1"
 toml = "0.8.19"
 walkdir = "2.5.0"

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,5 +1,6 @@
 pub mod assets;
 pub mod build;
+mod cleanup;
 pub mod costumes;
 pub mod datalists;
 pub mod debug_info;

--- a/src/codegen/assets.rs
+++ b/src/codegen/assets.rs
@@ -1,29 +1,18 @@
 use std::{
     cell::RefCell,
-    io::{
-        self,
-        Write,
-    },
     path::PathBuf,
     rc::Rc,
 };
 
-use fxhash::{
-    FxHashMap,
-    FxHashSet,
-};
+use fxhash::FxHashMap;
 use md5::{
     Digest,
     Md5,
 };
-use zip::write::SimpleFileOptions;
 
 use crate::{
     ast::Asset,
-    codegen::sb3::{
-        Sb3,
-        D,
-    },
+    codegen::sb3::D,
     misc::SmolStr,
     vfs::VFS,
 };
@@ -84,25 +73,5 @@ impl AssetObjectStore {
 
     pub fn get_objects(&self) -> impl Iterator<Item = &AssetObject> {
         self.store.values()
-    }
-}
-
-impl<T> Sb3<T>
-where T: io::Write + io::Seek
-{
-    pub fn assets(&mut self) -> io::Result<()> {
-        let mut added = FxHashSet::default();
-        for object in self.asset_object_store.get_objects() {
-            if added.contains(&&*object.hash) {
-                continue;
-            }
-            added.insert(object.hash.as_str());
-            self.zip.start_file(
-                format!("{}.{}", object.hash, object.extension),
-                SimpleFileOptions::default(),
-            )?;
-            self.zip.write_all(&object.content)?;
-        }
-        Ok(())
     }
 }

--- a/src/codegen/assets.rs
+++ b/src/codegen/assets.rs
@@ -19,8 +19,8 @@ use crate::{
 
 #[derive(Debug, Default)]
 pub struct AssetObject {
-    pub hash: String,
-    pub extension: String,
+    pub hash: SmolStr,
+    pub extension: SmolStr,
     pub content: Vec<u8>,
 }
 
@@ -58,11 +58,12 @@ impl AssetObjectStore {
                 .rsplit_once('.')
                 .unwrap_or_default()
                 .1
-                .to_lowercase();
+                .to_lowercase()
+                .into();
 
             let mut hasher = Md5::new();
             hasher.update(&content);
-            let hash = format!("{:x}", hasher.finalize()).to_string();
+            let hash = arcstr::format!("{:x}", hasher.finalize());
             AssetObject {
                 hash,
                 content,

--- a/src/codegen/build.rs
+++ b/src/codegen/build.rs
@@ -10,7 +10,14 @@ use std::{
 
 use anyhow::Context;
 use directories::ProjectDirs;
-use fxhash::FxHashMap;
+use fxhash::{
+    FxHashMap,
+    FxHashSet,
+};
+use zip::{
+    write::SimpleFileOptions,
+    ZipWriter,
+};
 
 use crate::{
     ast::{
@@ -38,7 +45,7 @@ use crate::{
 pub fn build_impl<T: Write + Seek>(
     fs: Rc<RefCell<dyn VFS>>,
     input: PathBuf,
-    mut sb3: Sb3<T>,
+    file: T,
     stdlib: Option<StandardLibrary>,
 ) -> anyhow::Result<Artifact> {
     let config_path = input.join("goboscript.toml");
@@ -139,7 +146,8 @@ pub fn build_impl<T: Write + Seek>(
     visitor::pass3::visit_project(&mut project);
     visitor::pass4::visit_project(&mut project);
     log::info!("{:#?}", project);
-    sb3.project(
+    let mut sb3 = Sb3::new(fs.clone(), input.clone());
+    let json = sb3.project(
         fs.clone(),
         &input,
         &project,
@@ -148,7 +156,25 @@ pub fn build_impl<T: Write + Seek>(
         &mut sprites_diagnostics,
     )?;
     let node_count = sb3.block_count;
-    drop(sb3);
+    let mut zip = ZipWriter::new(file);
+    // TODO: make compression configurable: store in debug, deflate in release.
+    zip.start_file(
+        "project.json",
+        SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated),
+    )?;
+    serde_json::to_writer(&mut zip, &json)?;
+    let mut added = FxHashSet::default();
+    for object in sb3.asset_object_store.get_objects() {
+        if !added.insert(&object.hash) {
+            continue;
+        }
+        zip.start_file(
+            format!("{}.{}", object.hash, object.extension),
+            SimpleFileOptions::default(),
+        )?;
+        zip.write_all(&object.content)?;
+    }
+    zip.finish()?;
     Ok(Artifact {
         project,
         stage_diagnostics,

--- a/src/codegen/cleanup.rs
+++ b/src/codegen/cleanup.rs
@@ -1,0 +1,111 @@
+use serde_json::{
+    Map,
+    Value,
+};
+
+const GRID_SIZE: i64 = 40;
+const MARGIN: i64 = 8;
+const SCRIPT_SPACING: i64 = GRID_SIZE * 2;
+
+const HAT_PRIORITY: &[&str] = &[
+    "event_whenflagclicked",
+    "event_whenkeypressed",
+    "event_whenthisspriteclicked",
+    "event_whenbroadcastreceived",
+    "event_whengreaterthan",
+    "control_start_as_clone",
+    "procedures_definition",
+];
+const C_SHAPED_OPCODES: &[&str] = &[
+    "control_repeat",
+    "control_repeat_until",
+    "control_while",
+    "control_for_each",
+    "control_forever",
+    "control_if",
+    "control_if_else",
+    "control_all_at_once",
+];
+
+pub(super) fn clean(project: &mut Value) {
+    for target in project["targets"].as_array_mut().unwrap() {
+        clean_target(target);
+    }
+}
+
+fn clean_target(target: &mut Value) {
+    let blocks = target["blocks"].as_object_mut().unwrap();
+    let mut parents: Vec<_> = blocks
+        .iter()
+        .filter(|(_, block)| block["topLevel"].as_bool() == Some(true))
+        .map(|(id, block)| (id.clone(), hat_priority(block)))
+        .collect();
+    parents.sort_by_key(|parent| parent.1);
+
+    let mut y = 0;
+    for (id, _) in parents {
+        let height = height_stack(blocks, Some(&id))
+            + (blocks[&id]["opcode"] == "procedures_definition") as i64 * MARGIN * 2;
+        let block = blocks[&id].as_object_mut().unwrap();
+        block.insert("x".into(), 0.into());
+        block.insert("y".into(), y.into());
+        y += height + SCRIPT_SPACING;
+    }
+}
+
+fn hat_priority(block: &Value) -> usize {
+    let opcode = block["opcode"].as_str().unwrap();
+    HAT_PRIORITY
+        .iter()
+        .position(|it| *it == opcode)
+        .unwrap_or(1000)
+}
+
+fn height_stack(blocks: &Map<String, Value>, id: Option<&str>) -> i64 {
+    let Some(id) = id else { return 0 };
+    let block = &blocks[id];
+    let opcode = block["opcode"].as_str().unwrap();
+    let inputs = block["inputs"].as_object();
+    let mut height = GRID_SIZE + MARGIN + opcode.starts_with("pen_") as i64 * MARGIN;
+    let mut input_height = 0;
+    let mut nested_height = 0;
+
+    if let Some(inputs) = inputs {
+        for (name, input) in inputs {
+            let kind = input[0].as_u64();
+            if kind == Some(2) && matches!(name.as_str(), "SUBSTACK" | "SUBSTACK2") {
+                nested_height += height_stack(blocks, input[1].as_str()).max(24) + 32;
+            } else if matches!(kind, Some(2 | 3)) {
+                input_height = input_height.max(height_reporter(blocks, &input[1]) + MARGIN);
+            }
+        }
+    }
+    if C_SHAPED_OPCODES.contains(&opcode)
+        && inputs.is_none_or(|inputs| !inputs.contains_key("SUBSTACK"))
+    {
+        nested_height += 24 + 32;
+    }
+    if opcode == "control_if_else" && inputs.is_none_or(|inputs| !inputs.contains_key("SUBSTACK2"))
+    {
+        nested_height += 24 + 32;
+    }
+
+    height = height.max(input_height) + nested_height;
+    height + height_stack(blocks, block["next"].as_str())
+}
+
+fn height_reporter(blocks: &Map<String, Value>, id: &Value) -> i64 {
+    let Some(id) = id.as_str() else {
+        return if id.is_null() { 0 } else { GRID_SIZE };
+    };
+    let block = &blocks[id];
+    let mut height = GRID_SIZE;
+    if let Some(inputs) = block["inputs"].as_object() {
+        for input in inputs.values() {
+            if matches!(input[0].as_u64(), Some(2 | 3)) && !input[1].is_null() {
+                height = height.max(height_reporter(blocks, &input[1]) + MARGIN);
+            }
+        }
+    }
+    height
+}

--- a/src/codegen/costumes.rs
+++ b/src/codegen/costumes.rs
@@ -21,31 +21,31 @@ pub const VECTOR_FORMATS: &[&str] = &["svg"];
 impl Sb3 {
     pub fn costume(&mut self, config: &Config, costume: &Asset, d: D) -> io::Result<()> {
         let object = self.asset_object_store.load(costume, d);
-        let hash = object.hash.clone();
-        let extension = object.extension.clone();
-        if !(BITMAP_FORMATS.contains(&extension.as_str())
-            || VECTOR_FORMATS.contains(&extension.as_str()))
+        let hash = &object.hash;
+        let extension = &object.extension;
+        if !(BITMAP_FORMATS.iter().any(|format| extension == format)
+            || VECTOR_FORMATS.iter().any(|format| extension == format))
             && d.find_diagnostic_for_span(&costume.span).is_none()
         {
             d.report(
                 DiagnosticKind::InvalidCostumeFormat {
-                    extension: extension.as_str().into(),
+                    extension: extension.clone(),
                 },
                 &costume.span,
             );
         }
-        write!(self, "{{")?;
-        write!(self, r#""name":{}"#, json!(&*costume.name))?;
-        write!(self, r#","assetId":"{}""#, hash)?;
-        if BITMAP_FORMATS.contains(&extension.as_str()) {
+        write!(self.json, "{{")?;
+        write!(self.json, r#""name":{}"#, json!(&*costume.name))?;
+        write!(self.json, r#","assetId":"{}""#, hash)?;
+        if BITMAP_FORMATS.iter().any(|format| extension == format) {
             write!(
-                self,
+                self.json,
                 r#","bitmapResolution":{}"#,
                 json!(config.bitmap_resolution.unwrap_or(1))
             )?;
         }
-        write!(self, r#","dataFormat":"{}""#, extension)?;
-        write!(self, r#","md5ext":"{}.{}""#, hash, extension)?;
-        write!(self, "}}") // costume
+        write!(self.json, r#","dataFormat":"{}""#, extension)?;
+        write!(self.json, r#","md5ext":"{}.{}""#, hash, extension)?;
+        write!(self.json, "}}") // costume
     }
 }

--- a/src/codegen/costumes.rs
+++ b/src/codegen/costumes.rs
@@ -18,34 +18,34 @@ use crate::{
 pub const BITMAP_FORMATS: &[&str] = &["png", "bmp", "jpeg", "jpg", "gif"];
 pub const VECTOR_FORMATS: &[&str] = &["svg"];
 
-impl<T> Sb3<T>
-where T: io::Write + io::Seek
-{
+impl Sb3 {
     pub fn costume(&mut self, config: &Config, costume: &Asset, d: D) -> io::Result<()> {
         let object = self.asset_object_store.load(costume, d);
-        let extension = &*object.extension;
-        if !(BITMAP_FORMATS.contains(&extension) || VECTOR_FORMATS.contains(&extension))
+        let hash = object.hash.clone();
+        let extension = object.extension.clone();
+        if !(BITMAP_FORMATS.contains(&extension.as_str())
+            || VECTOR_FORMATS.contains(&extension.as_str()))
             && d.find_diagnostic_for_span(&costume.span).is_none()
         {
             d.report(
                 DiagnosticKind::InvalidCostumeFormat {
-                    extension: extension.into(),
+                    extension: extension.as_str().into(),
                 },
                 &costume.span,
             );
         }
-        write!(self.zip, "{{")?;
-        write!(self.zip, r#""name":{}"#, json!(&*costume.name))?;
-        write!(self.zip, r#","assetId":"{}""#, object.hash)?;
-        if BITMAP_FORMATS.contains(&extension) {
+        write!(self, "{{")?;
+        write!(self, r#""name":{}"#, json!(&*costume.name))?;
+        write!(self, r#","assetId":"{}""#, hash)?;
+        if BITMAP_FORMATS.contains(&extension.as_str()) {
             write!(
-                self.zip,
+                self,
                 r#","bitmapResolution":{}"#,
                 json!(config.bitmap_resolution.unwrap_or(1))
             )?;
         }
-        write!(self.zip, r#","dataFormat":"{}""#, extension)?;
-        write!(self.zip, r#","md5ext":"{}.{}""#, object.hash, extension)?;
-        write!(self.zip, "}}") // costume
+        write!(self, r#","dataFormat":"{}""#, extension)?;
+        write!(self, r#","md5ext":"{}.{}""#, hash, extension)?;
+        write!(self, "}}") // costume
     }
 }

--- a/src/codegen/event.rs
+++ b/src/codegen/event.rs
@@ -1,8 +1,4 @@
-use std::io::{
-    self,
-    Seek,
-    Write,
-};
+use std::io;
 
 use logos::Span;
 
@@ -19,9 +15,7 @@ use crate::{
     misc::SmolStr,
 };
 
-impl<T> Sb3<T>
-where T: Write + Seek
-{
+impl Sb3 {
     pub fn on(&mut self, event: &SmolStr) -> io::Result<()> {
         self.single_field_id("BROADCAST_OPTION", event)?;
         self.end_obj() // node

--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -139,10 +139,10 @@ impl Sb3 {
         }
         if menu_is_default {
             if std::mem::replace(&mut self.inputs_comma, true) {
-                self.write_all(b",")?;
+                self.json.write_all(b",")?;
             }
             write!(
-                self,
+                self.json,
                 r#""{}":[1,{}]"#,
                 repr.menu().unwrap().input,
                 menu_id.unwrap()
@@ -150,7 +150,7 @@ impl Sb3 {
         }
         self.end_obj()?; // inputs
         if let Some(fields) = repr.fields() {
-            write!(self, r#","fields":{fields}"#)?;
+            write!(self.json, r#","fields":{fields}"#)?;
         }
         self.end_obj()?; // node
         for (arg, arg_id) in args.iter().zip(arg_ids) {
@@ -199,7 +199,7 @@ impl Sb3 {
         self.input(s, d, op.input(), opr, opr_id, matches!(op, UnOp::Not))?;
         self.end_obj()?; // inputs
         if let Some(fields) = op.fields() {
-            write!(self, r#","fields":{fields}"#)?;
+            write!(self.json, r#","fields":{fields}"#)?;
         }
         self.end_obj()?; // node
         self.expr(s, d, opr, opr_id, this_id)
@@ -451,7 +451,7 @@ impl Sb3 {
         }
         self.end_obj()?; // inputs
         write!(
-            self,
+            self.json,
             "{}",
             Mutation::call(func.name.clone(), &qualified_args, true, false)
         )?;
@@ -493,13 +493,13 @@ impl Sb3 {
                         let qualified_list_name = QualifiedName::List(qualified_name, Type::Value);
                         match qualified_list_name {
                             QualifiedName::Var(qname, _) => {
-                                write!(self, "[3,[12,{},{}],", json!(*qname), json!(*qname))?;
+                                write!(self.json, "[3,[12,{},{}],", json!(*qname), json!(*qname))?;
                             }
                             QualifiedName::List(qname, _) => {
-                                write!(self, "[3,[13,{},{}],", json!(*qname), json!(*qname))?;
+                                write!(self.json, "[3,[13,{},{}],", json!(*qname), json!(*qname))?;
                             }
                         }
-                        return write!(self, "[10, \"\"]]");
+                        return write!(self.json, "[10, \"\"]]");
                     }
 
                     d.report(
@@ -566,7 +566,7 @@ impl Sb3 {
         self.begin_node(Node::new("sensing_of", this_id).parent_id(parent_id))?;
         self.begin_inputs()?;
         if is_default {
-            write!(self, r#""OBJECT":[1,{}]"#, menu_id)?;
+            write!(self.json, r#""OBJECT":[1,{}]"#, menu_id)?;
         } else {
             self.input_with_shadow(s, d, "OBJECT", object, object_id, menu_id)?;
         }

--- a/src/codegen/expr.rs
+++ b/src/codegen/expr.rs
@@ -1,6 +1,5 @@
 use std::io::{
     self,
-    Seek,
     Write,
 };
 
@@ -31,15 +30,10 @@ use crate::{
         UnOp,
     },
     diagnostic::DiagnosticKind,
-    misc::{
-        write_comma_io,
-        SmolStr,
-    },
+    misc::SmolStr,
 };
 
-impl<T> Sb3<T>
-where T: Write + Seek
-{
+impl Sb3 {
     pub fn arg(
         &mut self,
         s: S,
@@ -144,7 +138,9 @@ where T: Write + Seek
             }
         }
         if menu_is_default {
-            write_comma_io(&mut self.zip, &mut self.inputs_comma)?;
+            if std::mem::replace(&mut self.inputs_comma, true) {
+                self.write_all(b",")?;
+            }
             write!(
                 self,
                 r#""{}":[1,{}]"#,

--- a/src/codegen/input.rs
+++ b/src/codegen/input.rs
@@ -1,6 +1,5 @@
 use std::io::{
     self,
-    Seek,
     Write,
 };
 
@@ -26,7 +25,6 @@ use crate::{
         Repr,
         UnOp,
     },
-    misc::write_comma_io,
 };
 
 pub fn is_expr_boolean(expr: &Expr, s: S) -> bool {
@@ -76,9 +74,7 @@ pub fn coerce_condition(expr: &Expr, s: S) -> Expr {
     BinOp::Eq.to_expr(0..0, expr.clone(), Value::from(true).to_expr(0..0))
 }
 
-impl<T> Sb3<T>
-where T: Write + Seek
-{
+impl Sb3 {
     pub fn input(
         &mut self,
         s: S,
@@ -113,7 +109,9 @@ where T: Write + Seek
         shadow_id: Option<NodeID>,
         no_empty_shadow: bool,
     ) -> io::Result<()> {
-        write_comma_io(&mut self.zip, &mut self.inputs_comma)?;
+        if std::mem::replace(&mut self.inputs_comma, true) {
+            self.write_all(b",")?;
+        }
         write!(self, r#""{input_name}":"#)?;
         match expr {
             Expr::Value { value, span: _ } => return self.value_input(input_name, value),

--- a/src/codegen/input.rs
+++ b/src/codegen/input.rs
@@ -110,9 +110,9 @@ impl Sb3 {
         no_empty_shadow: bool,
     ) -> io::Result<()> {
         if std::mem::replace(&mut self.inputs_comma, true) {
-            self.write_all(b",")?;
+            self.json.write_all(b",")?;
         }
-        write!(self, r#""{input_name}":"#)?;
+        write!(self.json, r#""{input_name}":"#)?;
         match expr {
             Expr::Value { value, span: _ } => return self.value_input(input_name, value),
             Expr::Name(name) => return self.name_input(s, d, input_name, name, shadow_id),
@@ -124,24 +124,24 @@ impl Sb3 {
     fn value_input(&mut self, name: &str, value: &Value) -> io::Result<()> {
         match value {
             Value::Boolean(boolean) => {
-                write!(self, "[1,[4,{}]]", json!(*boolean as i64))
+                write!(self.json, "[1,[4,{}]]", json!(*boolean as i64))
             }
             Value::Number(number) if number.is_infinite() || number.is_nan() => match number {
                 n if n.is_infinite() && *n > 0.0 => {
-                    write!(self, "[1,[4,\"Infinity\"]]")
+                    write!(self.json, "[1,[4,\"Infinity\"]]")
                 }
                 n if n.is_infinite() && *n < 0.0 => {
-                    write!(self, "[1,[4,\"-Infinity\"]]")
+                    write!(self.json, "[1,[4,\"-Infinity\"]]")
                 }
                 _ => {
-                    write!(self, "[1,[4,\"NaN\"]]")
+                    write!(self.json, "[1,[4,\"NaN\"]]")
                 }
             },
             Value::Number(number) if number.fract() == 0.0 => {
-                write!(self, "[1,[4,{}]]", json!(*number as i64))
+                write!(self.json, "[1,[4,{}]]", json!(*number as i64))
             }
             Value::Number(number) => {
-                write!(self, "[1,[4,{}]]", json!(number))
+                write!(self.json, "[1,[4,{}]]", json!(number))
             }
             Value::String(string) => {
                 let color = ["COLOR", "COLOR2"]
@@ -153,11 +153,16 @@ impl Sb3 {
                     })
                     .flatten();
                 if name == "BROADCAST_INPUT" {
-                    write!(self, "[1,[11,{},{}]]", json!(**string), json!(**string))
+                    write!(
+                        self.json,
+                        "[1,[11,{},{}]]",
+                        json!(**string),
+                        json!(**string)
+                    )
                 } else if let Some(color) = color {
-                    write!(self, "[1,[9,{}]]", json!(color.to_css_hex()))
+                    write!(self.json, "[1,[9,{}]]", json!(color.to_css_hex()))
                 } else {
-                    write!(self, "[1,[10,{}]]", json!(**string))
+                    write!(self.json, "[1,[10,{}]]", json!(**string))
                 }
             }
         }
@@ -174,11 +179,11 @@ impl Sb3 {
         match s.qualify_name(Some(d), name) {
             Some(QualifiedName::Var(name, _)) => {
                 self.block_count += 1;
-                write!(self, "[3,[12,{},{}],", json!(*name), json!(*name))?;
+                write!(self.json, "[3,[12,{},{}],", json!(*name), json!(*name))?;
             }
             Some(QualifiedName::List(name, _)) => {
                 self.block_count += 1;
-                write!(self, "[3,[13,{},{}],", json!(*name), json!(*name))?;
+                write!(self.json, "[3,[13,{},{}],", json!(*name), json!(*name))?;
             }
             None => {}
         }
@@ -193,20 +198,20 @@ impl Sb3 {
         no_empty_shadow: bool,
     ) -> io::Result<()> {
         if no_empty_shadow {
-            return write!(self, "[2,{node_id}]");
+            return write!(self.json, "[2,{node_id}]");
         }
-        write!(self, "[3,{node_id},")?;
+        write!(self.json, "[3,{node_id},")?;
         self.shadow_input(input_name, shadow_id)
     }
 
     fn shadow_input(&mut self, input_name: &str, shadow_id: Option<NodeID>) -> io::Result<()> {
         if let Some(shadow_id) = shadow_id {
-            write!(self, "{shadow_id}]")
+            write!(self.json, "{shadow_id}]")
         } else if input_name == "BROADCAST_INPUT" {
             let broadcast_name = json!("message1");
-            write!(self, "[11,{},{}]]", broadcast_name, broadcast_name)
+            write!(self.json, "[11,{},{}]]", broadcast_name, broadcast_name)
         } else {
-            write!(self, r#"[10, ""]]"#)
+            write!(self.json, r#"[10, ""]]"#)
         }
     }
 }

--- a/src/codegen/sb3.rs
+++ b/src/codegen/sb3.rs
@@ -3,7 +3,6 @@ use std::{
     cell::RefCell,
     io::{
         self,
-        Seek,
         Write,
     },
     path::{
@@ -20,12 +19,9 @@ use fxhash::{
 };
 use logos::Span;
 use serde_json::json;
-use zip::{
-    write::SimpleFileOptions,
-    ZipWriter,
-};
 
 use super::{
+    cleanup,
     node::Node,
     node_id::NodeID,
     node_id_factory::NodeIDFactory,
@@ -330,10 +326,8 @@ impl Stmt {
     }
 }
 
-pub struct Sb3<T>
-where T: Write + Seek
-{
-    pub zip: ZipWriter<T>,
+pub struct Sb3 {
+    json: Vec<u8>,
     pub id: NodeIDFactory,
     pub node_comma: bool,
     pub inputs_comma: bool,
@@ -342,24 +336,20 @@ where T: Write + Seek
     extensions: Extensions,
 }
 
-impl<T> Write for Sb3<T>
-where T: Write + Seek
-{
+impl Write for Sb3 {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.zip.write(buf)
+        self.json.write(buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        self.zip.flush()
+        self.json.flush()
     }
 }
 
-impl<T> Sb3<T>
-where T: Write + Seek
-{
-    pub fn new(file: T, fs: Rc<RefCell<dyn VFS>>, input: PathBuf) -> Self {
+impl Sb3 {
+    pub fn new(fs: Rc<RefCell<dyn VFS>>, input: PathBuf) -> Self {
         Self {
-            zip: ZipWriter::new(file),
+            json: Vec::new(),
             id: NodeIDFactory::new(),
             node_comma: false,
             inputs_comma: false,
@@ -376,7 +366,7 @@ where T: Write + Seek
         } else if node.opcode.starts_with("music_") {
             self.extensions.music = true;
         }
-        write_comma_io(&mut self.zip, &mut self.node_comma)?;
+        write_comma_io(&mut self.json, &mut self.node_comma)?;
         write!(self, "{node}")
     }
 
@@ -406,7 +396,7 @@ where T: Write + Seek
         let Some(this_id) = this_id else {
             return Ok(());
         };
-        write_comma_io(&mut self.zip, &mut self.inputs_comma)?;
+        write_comma_io(&mut self.json, &mut self.inputs_comma)?;
         write!(self, r#""{name}":[2,{this_id}]"#)
     }
 
@@ -418,7 +408,7 @@ where T: Write + Seek
         config: &Config,
         stage_diagnostics: D,
         sprites_diagnostics: &mut FxHashMap<SmolStr, SpriteDiagnostics>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<serde_json::Value> {
         let layers = compute_layers(project, config)?;
         let broadcasts: FxHashSet<_> = project
             .stage
@@ -433,13 +423,6 @@ where T: Write + Seek
                 }
             })
             .collect();
-        // TODO: switch to deflate compression
-        // this should be configurable, use store in debug (because it would be
-        // faster?), use deflate in release (because it would be smaller?)
-        self.zip.start_file(
-            "project.json",
-            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated),
-        )?;
         write!(self, "{{")?;
         write!(self, r#""targets":["#)?;
         self.sprite(
@@ -492,8 +475,9 @@ where T: Write + Seek
         )?;
         write!(self, "}}")?; // meta
         write!(self, "}}")?; // project
-        self.assets()?;
-        Ok(())
+        let mut json = serde_json::from_slice(&self.json)?;
+        cleanup::clean(&mut json);
+        Ok(json)
     }
 
     pub fn sprite(
@@ -591,7 +575,7 @@ where T: Write + Seek
         if stage.is_none() {
             let mut comma = false;
             for broadcast in broadcasts {
-                write_comma_io(&mut self.zip, &mut comma)?;
+                write_comma_io(&mut self.json, &mut comma)?;
                 write!(self, r#"{}:{}"#, json!(**broadcast), json!(**broadcast))?;
             }
         }
@@ -727,14 +711,14 @@ where T: Write + Seek
         write!(self, r#","costumes":["#)?;
         let mut comma = false;
         for costume in &sprite.costumes {
-            write_comma_io(&mut self.zip, &mut comma)?;
+            write_comma_io(&mut self.json, &mut comma)?;
             self.costume(config, costume, d)?;
         }
         write!(self, "]")?; // costumes
         write!(self, r#","sounds":["#)?;
         let mut comma = false;
         for sound in &sprite.sounds {
-            write_comma_io(&mut self.zip, &mut comma)?;
+            write_comma_io(&mut self.json, &mut comma)?;
             self.sound(sound, d)?;
         }
         write!(self, "]")?; // sounds
@@ -776,7 +760,7 @@ where T: Write + Seek
         is_cloud: bool,
         comma: &mut bool,
     ) -> io::Result<()> {
-        write_comma_io(&mut self.zip, comma)?;
+        write_comma_io(&mut self.json, comma)?;
         let default = default.unwrap_or(Value::from(0.0));
         if is_cloud {
             write!(
@@ -959,7 +943,7 @@ where T: Write + Seek
         };
         match &list.type_ {
             Type::Value => {
-                write_comma_io(&mut self.zip, comma)?;
+                write_comma_io(&mut self.json, comma)?;
                 write!(self, r#""{}":["{}",{}]"#, list.name, list.name, json!(data))?;
             }
             Type::Struct {
@@ -975,7 +959,7 @@ where T: Write + Seek
                 };
                 for (i, field) in struct_.fields.iter().enumerate() {
                     let qualified_list_name = qualify_struct_var_name(&field.name, &list.name);
-                    write_comma_io(&mut self.zip, comma)?;
+                    write_comma_io(&mut self.json, comma)?;
                     let column = (0..(data.len() / struct_.fields.len()))
                         .map(|j| &data[j * struct_.fields.len() + i])
                         .collect::<Vec<_>>();
@@ -1053,7 +1037,7 @@ where T: Write + Seek
         self.begin_inputs()?;
         let mut comma = false;
         for (qualified_arg_name, arg_id) in &qualified_args {
-            write_comma_io(&mut self.zip, &mut comma)?;
+            write_comma_io(&mut self.json, &mut comma)?;
             write!(self, r#"{}:[2,{arg_id}]"#, json!(**qualified_arg_name))?;
         }
         self.end_obj()?; // inputs
@@ -1127,7 +1111,7 @@ where T: Write + Seek
         self.begin_inputs()?;
         let mut comma = false;
         for (qualified_arg_name, arg_id) in &qualified_args {
-            write_comma_io(&mut self.zip, &mut comma)?;
+            write_comma_io(&mut self.json, &mut comma)?;
             write!(self, r#"{}:[2,{arg_id}]"#, json!(**qualified_arg_name))?;
         }
         self.end_obj()?; // inputs

--- a/src/codegen/sb3.rs
+++ b/src/codegen/sb3.rs
@@ -327,23 +327,13 @@ impl Stmt {
 }
 
 pub struct Sb3 {
-    json: Vec<u8>,
+    pub json: Vec<u8>,
     pub id: NodeIDFactory,
     pub node_comma: bool,
     pub inputs_comma: bool,
     pub block_count: usize,
     pub asset_object_store: AssetObjectStore,
     extensions: Extensions,
-}
-
-impl Write for Sb3 {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.json.write(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.json.flush()
-    }
 }
 
 impl Sb3 {
@@ -367,25 +357,29 @@ impl Sb3 {
             self.extensions.music = true;
         }
         write_comma_io(&mut self.json, &mut self.node_comma)?;
-        write!(self, "{node}")
+        write!(self.json, "{node}")
     }
 
     pub fn end_obj(&mut self) -> io::Result<()> {
-        self.write_all(b"}")
+        self.json.write_all(b"}")
     }
 
     pub fn begin_inputs(&mut self) -> io::Result<()> {
         self.inputs_comma = false;
-        self.write_all(br#","inputs":{"#)
+        self.json.write_all(br#","inputs":{"#)
     }
 
     pub fn single_field(&mut self, name: &'static str, value: &str) -> io::Result<()> {
-        write!(self, r#","fields":{{"{name}":[{},null]}}"#, json!(value))
+        write!(
+            self.json,
+            r#","fields":{{"{name}":[{},null]}}"#,
+            json!(value)
+        )
     }
 
     pub fn single_field_id(&mut self, name: &'static str, value: &str) -> io::Result<()> {
         write!(
-            self,
+            self.json,
             r#","fields":{{"{name}":[{},{}]}}"#,
             json!(value),
             json!(value)
@@ -397,7 +391,7 @@ impl Sb3 {
             return Ok(());
         };
         write_comma_io(&mut self.json, &mut self.inputs_comma)?;
-        write!(self, r#""{name}":[2,{this_id}]"#)
+        write!(self.json, r#""{name}":[2,{this_id}]"#)
     }
 
     pub fn project(
@@ -423,8 +417,8 @@ impl Sb3 {
                 }
             })
             .collect();
-        write!(self, "{{")?;
-        write!(self, r#""targets":["#)?;
+        write!(self.json, "{{")?;
+        write!(self.json, r#""targets":["#)?;
         self.sprite(
             fs.clone(),
             input,
@@ -439,7 +433,7 @@ impl Sb3 {
         let mut sprite_names: Vec<_> = project.sprites.keys().collect();
         sprite_names.sort();
         for sprite_name in sprite_names {
-            write!(self, r#","#)?;
+            write!(self.json, r#","#)?;
             self.sprite(
                 fs.clone(),
                 input,
@@ -452,29 +446,29 @@ impl Sb3 {
                 layers[sprite_name],
             )?;
         }
-        write!(self, "]")?; // targets
-        write!(self, r#","monitors":[]"#)?;
+        write!(self.json, "]")?; // targets
+        write!(self.json, r#","monitors":[]"#)?;
         if self.extensions.pen && self.extensions.music {
-            write!(self, r#","extensions":["pen","music"]"#)?;
+            write!(self.json, r#","extensions":["pen","music"]"#)?;
         } else if self.extensions.pen {
-            write!(self, r#","extensions":["pen"]"#)?;
+            write!(self.json, r#","extensions":["pen"]"#)?;
         } else if self.extensions.music {
-            write!(self, r#","extensions":["music"]"#)?;
+            write!(self.json, r#","extensions":["music"]"#)?;
         } else {
-            write!(self, r#","extensions":[]"#)?;
+            write!(self.json, r#","extensions":[]"#)?;
         }
-        write!(self, r#","meta":{{"#)?;
-        write!(self, r#""semver":"3.0.0""#)?;
-        write!(self, r#","vm":"0.2.0""#)?;
+        write!(self.json, r#","meta":{{"#)?;
+        write!(self.json, r#""semver":"3.0.0""#)?;
+        write!(self.json, r#","vm":"0.2.0""#)?;
         write!(
-            self,
+            self.json,
             r#","agent":"goboscript ({})""#,
             option_env!("GIT_HASH")
                 .map(|hash| format!("commit {hash}"))
                 .unwrap_or_else(|| format!("v{}", env!("CARGO_PKG_VERSION")))
         )?;
-        write!(self, "}}")?; // meta
-        write!(self, "}}")?; // project
+        write!(self.json, "}}")?; // meta
+        write!(self.json, "}}")?; // project
         let mut json = serde_json::from_slice(&self.json)?;
         cleanup::clean(&mut json);
         Ok(json)
@@ -551,36 +545,41 @@ impl Sb3 {
             costumes.insert(&costume.name);
         }
         self.id.reset();
-        write!(self, "{{")?;
-        write!(self, r#""isStage":{}"#, name == STAGE_NAME)?;
-        write!(self, r#","name":{}"#, json!(name))?;
+        write!(self.json, "{{")?;
+        write!(self.json, r#""isStage":{}"#, name == STAGE_NAME)?;
+        write!(self.json, r#","name":{}"#, json!(name))?;
         if name == STAGE_NAME {
-            write!(self, r#","comments":{{"#)?;
-            write!(self, r#""twconfig":{{"#)?;
-            write!(self, r#""blockId":null"#)?;
-            write!(self, r#","x":0"#)?;
-            write!(self, r#","y":0"#)?;
-            write!(self, r#","width":350"#)?;
-            write!(self, r#","height":170"#)?;
-            write!(self, r#","minimized":false"#)?;
+            write!(self.json, r#","comments":{{"#)?;
+            write!(self.json, r#""twconfig":{{"#)?;
+            write!(self.json, r#""blockId":null"#)?;
+            write!(self.json, r#","x":0"#)?;
+            write!(self.json, r#","y":0"#)?;
+            write!(self.json, r#","width":350"#)?;
+            write!(self.json, r#","height":170"#)?;
+            write!(self.json, r#","minimized":false"#)?;
             write!(
-                self,
+                self.json,
                 r#","text":{}"#,
                 json!(TurbowarpConfig::from(config).to_string())
             )?;
-            write!(self, "}}")?; // twconfig
-            write!(self, "}}")?; // comments
+            write!(self.json, "}}")?; // twconfig
+            write!(self.json, "}}")?; // comments
         }
-        write!(self, r#","broadcasts":{{"#)?;
+        write!(self.json, r#","broadcasts":{{"#)?;
         if stage.is_none() {
             let mut comma = false;
             for broadcast in broadcasts {
                 write_comma_io(&mut self.json, &mut comma)?;
-                write!(self, r#"{}:{}"#, json!(**broadcast), json!(**broadcast))?;
+                write!(
+                    self.json,
+                    r#"{}:{}"#,
+                    json!(**broadcast),
+                    json!(**broadcast)
+                )?;
             }
         }
-        write!(self, "}}")?; // broadcasts
-        write!(self, r#","variables":{{"#)?;
+        write!(self.json, "}}")?; // broadcasts
+        write!(self.json, r#","variables":{{"#)?;
         let mut comma = false;
         for proc in sprite
             .procs
@@ -635,8 +634,8 @@ impl Sb3 {
                 d,
             )?;
         }
-        write!(self, "}}")?; // variables
-        write!(self, r#","lists":{{"#)?;
+        write!(self.json, "}}")?; // variables
+        write!(self.json, r#","lists":{{"#)?;
         let mut comma = false;
         for list in sprite.lists.values() {
             self.list_declaration(
@@ -653,8 +652,8 @@ impl Sb3 {
                 d,
             )?;
         }
-        write!(self, "}}")?; // lists
-        write!(self, r#","blocks":{{"#)?;
+        write!(self.json, "}}")?; // lists
+        write!(self.json, r#","blocks":{{"#)?;
         self.node_comma = false;
         for proc in sprite
             .procs
@@ -704,52 +703,52 @@ impl Sb3 {
                 event,
             )?;
         }
-        write!(self, "}}")?; // blocks
+        write!(self.json, "}}")?; // blocks
         if sprite.costumes.is_empty() {
             d.report(DiagnosticKind::NoCostumes, &(0..0));
         }
-        write!(self, r#","costumes":["#)?;
+        write!(self.json, r#","costumes":["#)?;
         let mut comma = false;
         for costume in &sprite.costumes {
             write_comma_io(&mut self.json, &mut comma)?;
             self.costume(config, costume, d)?;
         }
-        write!(self, "]")?; // costumes
-        write!(self, r#","sounds":["#)?;
+        write!(self.json, "]")?; // costumes
+        write!(self.json, r#","sounds":["#)?;
         let mut comma = false;
         for sound in &sprite.sounds {
             write_comma_io(&mut self.json, &mut comma)?;
             self.sound(sound, d)?;
         }
-        write!(self, "]")?; // sounds
+        write!(self.json, "]")?; // sounds
         if let Some((x_position, _)) = &sprite.x_position {
             let x_position = x_position.to_js_number();
-            write!(self, r#","x":{}"#, json!(x_position))?;
+            write!(self.json, r#","x":{}"#, json!(x_position))?;
         }
         if let Some((y_position, _)) = &sprite.y_position {
             let y_position = y_position.to_js_number();
-            write!(self, r#","y":{}"#, json!(y_position))?;
+            write!(self.json, r#","y":{}"#, json!(y_position))?;
         }
         if let Some((size, _)) = &sprite.size {
             let size = size.to_js_number();
-            write!(self, r#","size":{}"#, json!(size))?;
+            write!(self.json, r#","size":{}"#, json!(size))?;
         }
         if let Some((direction, _)) = &sprite.direction {
             let direction = direction.to_js_number();
-            write!(self, r#","direction":{}"#, json!(direction))?;
+            write!(self.json, r#","direction":{}"#, json!(direction))?;
         }
         if let Some((volume, _)) = &sprite.volume {
             let volume = volume.to_js_number();
-            write!(self, r#","volume":{}"#, json!(volume))?;
+            write!(self.json, r#","volume":{}"#, json!(volume))?;
         }
-        write!(self, r#","layerOrder":{}"#, layer_order)?;
+        write!(self.json, r#","layerOrder":{}"#, layer_order)?;
         if !sprite.hidden {
-            write!(self, r#","visible":true"#)?;
+            write!(self.json, r#","visible":true"#)?;
         } else {
-            write!(self, r#","visible":false"#)?;
+            write!(self.json, r#","visible":false"#)?;
         }
-        write!(self, r#","rotationStyle":"{}""#, sprite.rotation_style)?;
-        write!(self, "}}")?; // sprite
+        write!(self.json, r#","rotationStyle":"{}""#, sprite.rotation_style)?;
+        write!(self.json, "}}")?; // sprite
         Ok(())
     }
 
@@ -764,7 +763,7 @@ impl Sb3 {
         let default = default.unwrap_or(Value::from(0.0));
         if is_cloud {
             write!(
-                self,
+                self.json,
                 "\"{}\":[\"\u{2601} {}\",{},true]",
                 var_name,
                 var_name,
@@ -772,7 +771,7 @@ impl Sb3 {
             )
         } else {
             write!(
-                self,
+                self.json,
                 "\"{}\":[\"{}\",{}]",
                 var_name,
                 var_name,
@@ -944,7 +943,13 @@ impl Sb3 {
         match &list.type_ {
             Type::Value => {
                 write_comma_io(&mut self.json, comma)?;
-                write!(self, r#""{}":["{}",{}]"#, list.name, list.name, json!(data))?;
+                write!(
+                    self.json,
+                    r#""{}":["{}",{}]"#,
+                    list.name,
+                    list.name,
+                    json!(data)
+                )?;
             }
             Type::Struct {
                 name: type_name,
@@ -964,7 +969,7 @@ impl Sb3 {
                         .map(|j| &data[j * struct_.fields.len() + i])
                         .collect::<Vec<_>>();
                     write!(
-                        self,
+                        self.json,
                         r#""{}":["{}",{}]"#,
                         qualified_list_name,
                         qualified_list_name,
@@ -986,7 +991,7 @@ impl Sb3 {
                 .top_level(true),
         )?;
         self.begin_inputs()?;
-        write!(self, r#""custom_block":[1,{prototype_id}]"#)?;
+        write!(self.json, r#""custom_block":[1,{prototype_id}]"#)?;
         self.end_obj()?; // inputs
         self.end_obj()?; // node
         let mut qualified_args: Vec<(SmolStr, NodeID)> = Vec::new();
@@ -1038,11 +1043,11 @@ impl Sb3 {
         let mut comma = false;
         for (qualified_arg_name, arg_id) in &qualified_args {
             write_comma_io(&mut self.json, &mut comma)?;
-            write!(self, r#"{}:[2,{arg_id}]"#, json!(**qualified_arg_name))?;
+            write!(self.json, r#"{}:[2,{arg_id}]"#, json!(**qualified_arg_name))?;
         }
         self.end_obj()?; // inputs
         write!(
-            self,
+            self.json,
             "{}",
             Mutation::prototype(proc.name.clone(), &qualified_args, proc.warp, false)
         )?;
@@ -1060,7 +1065,7 @@ impl Sb3 {
                 .top_level(true),
         )?;
         self.begin_inputs()?;
-        write!(self, r#""custom_block":[1,{prototype_id}]"#)?;
+        write!(self.json, r#""custom_block":[1,{prototype_id}]"#)?;
         self.end_obj()?; // inputs
         self.end_obj()?; // node
         let mut qualified_args: Vec<(SmolStr, NodeID)> = Vec::new();
@@ -1112,11 +1117,11 @@ impl Sb3 {
         let mut comma = false;
         for (qualified_arg_name, arg_id) in &qualified_args {
             write_comma_io(&mut self.json, &mut comma)?;
-            write!(self, r#"{}:[2,{arg_id}]"#, json!(**qualified_arg_name))?;
+            write!(self.json, r#"{}:[2,{arg_id}]"#, json!(**qualified_arg_name))?;
         }
         self.end_obj()?; // inputs
         write!(
-            self,
+            self.json,
             "{}",
             Mutation::prototype(func.name.clone(), &qualified_args, true, false)
         )?;

--- a/src/codegen/sounds.rs
+++ b/src/codegen/sounds.rs
@@ -19,24 +19,24 @@ pub const SOUND_FORMATS: &[&str] = &["wav", "wave", "mp3"];
 impl Sb3 {
     pub fn sound(&mut self, sound: &Asset, d: D) -> io::Result<()> {
         let object = self.asset_object_store.load(sound, d);
-        let hash = object.hash.clone();
-        let extension = object.extension.clone();
+        let hash = &object.hash;
+        let extension = &object.extension;
         if !extension.is_empty()
-            && !SOUND_FORMATS.contains(&extension.as_str())
+            && !SOUND_FORMATS.iter().any(|format| extension == format)
             && d.find_diagnostic_for_span(&sound.span).is_none()
         {
             d.report(
                 DiagnosticKind::InvalidSoundFormat {
-                    extension: extension.as_str().into(),
+                    extension: extension.clone(),
                 },
                 &sound.span,
             );
         }
-        write!(self, "{{")?;
-        write!(self, r#""name":{}"#, json!(&*sound.name))?;
-        write!(self, r#","assetId":"{}""#, hash)?;
-        write!(self, r#","dataFormat":"{}""#, extension)?;
-        write!(self, r#","md5ext":"{}.{}""#, hash, extension)?;
-        write!(self, "}}") // sound
+        write!(self.json, "{{")?;
+        write!(self.json, r#""name":{}"#, json!(&*sound.name))?;
+        write!(self.json, r#","assetId":"{}""#, hash)?;
+        write!(self.json, r#","dataFormat":"{}""#, extension)?;
+        write!(self.json, r#","md5ext":"{}.{}""#, hash, extension)?;
+        write!(self.json, "}}") // sound
     }
 }

--- a/src/codegen/sounds.rs
+++ b/src/codegen/sounds.rs
@@ -16,28 +16,27 @@ use crate::{
 
 pub const SOUND_FORMATS: &[&str] = &["wav", "wave", "mp3"];
 
-impl<T> Sb3<T>
-where T: io::Write + io::Seek
-{
+impl Sb3 {
     pub fn sound(&mut self, sound: &Asset, d: D) -> io::Result<()> {
         let object = self.asset_object_store.load(sound, d);
-        let extension = &*object.extension;
+        let hash = object.hash.clone();
+        let extension = object.extension.clone();
         if !extension.is_empty()
-            && !SOUND_FORMATS.contains(&extension)
+            && !SOUND_FORMATS.contains(&extension.as_str())
             && d.find_diagnostic_for_span(&sound.span).is_none()
         {
             d.report(
                 DiagnosticKind::InvalidSoundFormat {
-                    extension: extension.into(),
+                    extension: extension.as_str().into(),
                 },
                 &sound.span,
             );
         }
-        write!(self.zip, "{{")?;
-        write!(self.zip, r#""name":{}"#, json!(&*sound.name))?;
-        write!(self.zip, r#","assetId":"{}""#, object.hash)?;
-        write!(self.zip, r#","dataFormat":"{}""#, extension)?;
-        write!(self.zip, r#","md5ext":"{}.{}""#, object.hash, extension)?;
-        write!(self.zip, "}}") // sound
+        write!(self, "{{")?;
+        write!(self, r#""name":{}"#, json!(&*sound.name))?;
+        write!(self, r#","assetId":"{}""#, hash)?;
+        write!(self, r#","dataFormat":"{}""#, extension)?;
+        write!(self, r#","md5ext":"{}.{}""#, hash, extension)?;
+        write!(self, "}}") // sound
     }
 }

--- a/src/codegen/stmt.rs
+++ b/src/codegen/stmt.rs
@@ -366,10 +366,10 @@ impl Sb3 {
         }
         if menu_is_default {
             if std::mem::replace(&mut self.inputs_comma, true) {
-                self.write_all(b",")?;
+                self.json.write_all(b",")?;
             }
             write!(
-                self,
+                self.json,
                 r#""{}":[1,{}]"#,
                 block.menu().unwrap().input,
                 menu_id.unwrap()
@@ -377,10 +377,10 @@ impl Sb3 {
         }
         self.end_obj()?; // inputs
         if let Some(fields) = block.fields() {
-            write!(self, r#","fields":{fields}"#)?;
+            write!(self.json, r#","fields":{fields}"#)?;
         }
         if let Block::StopOtherScripts = block {
-            self.write_all(
+            self.json.write_all(
                 b",\"mutation\":{\"tagName\":\"mutation\",\"children\": [],\"hasnext\": \"true\"}",
             )?;
         }
@@ -601,7 +601,7 @@ impl Sb3 {
         }
         self.end_obj()?; // inputs
         write!(
-            self,
+            self.json,
             "{}",
             Mutation::call(proc.name.clone(), &qualified_args, proc.warp, compact)
         )?;

--- a/src/codegen/stmt.rs
+++ b/src/codegen/stmt.rs
@@ -1,6 +1,5 @@
 use std::io::{
     self,
-    Seek,
     Write,
 };
 
@@ -31,15 +30,10 @@ use crate::{
     blocks::Block,
     codegen::mutation::Mutation,
     diagnostic::DiagnosticKind,
-    misc::{
-        write_comma_io,
-        SmolStr,
-    },
+    misc::SmolStr,
 };
 
-impl<T> Sb3<T>
-where T: Write + Seek
-{
+impl Sb3 {
     pub fn repeat(
         &mut self,
         s: S,
@@ -371,7 +365,9 @@ where T: Write + Seek
             }
         }
         if menu_is_default {
-            write_comma_io(&mut self.zip, &mut self.inputs_comma)?;
+            if std::mem::replace(&mut self.inputs_comma, true) {
+                self.write_all(b",")?;
+            }
             write!(
                 self,
                 r#""{}":[1,{}]"#,

--- a/src/diagnostic/diagnostic_kind.rs
+++ b/src/diagnostic/diagnostic_kind.rs
@@ -58,7 +58,7 @@ pub enum DiagnosticKind {
     InvalidCostumeName(SmolStr),
     InvalidBackdropName(SmolStr),
     InvalidCostumeFormat {
-        extension: String,
+        extension: SmolStr,
     },
     InvalidSoundFormat {
         extension: SmolStr,

--- a/src/frontend/build.rs
+++ b/src/frontend/build.rs
@@ -8,10 +8,7 @@ use std::{
 };
 
 use crate::{
-    codegen::{
-        build::build_impl,
-        sb3::Sb3,
-    },
+    codegen::build::build_impl,
     diagnostic::Artifact,
     vfs::RealFS,
 };
@@ -22,10 +19,6 @@ pub fn build(input: Option<PathBuf>, output: Option<PathBuf>) -> anyhow::Result<
     let project_name = canonical_input.file_name().unwrap().to_str().unwrap();
     let output = output.unwrap_or_else(|| input.join(format!("{project_name}.sb3")));
     let fs = Rc::new(RefCell::new(RealFS));
-    let sb3 = Sb3::new(
-        BufWriter::new(File::create(&output)?),
-        fs.clone(),
-        canonical_input.clone(),
-    );
-    build_impl(fs, canonical_input, sb3, None)
+    let file = BufWriter::new(File::create(&output)?);
+    build_impl(fs, canonical_input, file, None)
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -17,10 +17,7 @@ use wasm_bindgen::{
 
 use crate::{
     ast::Sprite,
-    codegen::{
-        build::build_impl,
-        sb3::Sb3,
-    },
+    codegen::build::build_impl,
     diagnostic::{
         Artifact,
         Diagnostic,
@@ -55,12 +52,11 @@ pub fn build(fs: JsValue) -> JsValue {
     let fs: MemFS = serde_wasm_bindgen::from_value(fs).unwrap();
     let fs = Rc::new(RefCell::new(fs));
     let mut file = Vec::new();
-    let sb3 = Sb3::new(Cursor::new(&mut file), fs.clone(), "project".into());
     let stdlib = StandardLibrary {
         path: "stdlib".into(),
         version: Version::new(0, 0, 0),
     };
-    let artifact = build_impl(fs, "project".into(), sb3, Some(stdlib)).unwrap();
+    let artifact = build_impl(fs, "project".into(), Cursor::new(&mut file), Some(stdlib)).unwrap();
     serde_wasm_bindgen::to_value(&Build { file, artifact }).unwrap()
 }
 


### PR DESCRIPTION
## Summary

- arrange generated Scratch scripts by hat priority on a consistent grid
- account for nested stacks, reporters, and C-shaped blocks when spacing scripts
- generate and clean `project.json` before assembling the `.sb3` archive
- move ZIP and asset writing out of `Sb3`, leaving it as a focused JSON generator

## Why

Generated scripts previously retained incidental coordinates instead of receiving a predictable, readable layout. Cleaning the completed JSON requires buffering it before archive creation, which exposed that `Sb3` was unnecessarily coupled to the ZIP writer.

The build layer now owns archive assembly while `Sb3` owns only project JSON generation and asset collection.

## Impact

Compiled Scratch projects open with consistently ordered, non-overlapping script stacks. Archive contents and asset deduplication remain unchanged.

## Validation

- `cargo +nightly fmt --check`
- `cargo test --lib` (12 passed)
- built `tests/vars` successfully
- verified the generated ZIP with `unzip -t`
- parsed the generated `project.json` with `jq`