### PR TITLE
fix: expand nested macro arguments

### DIFF
--- a/src/pre_processor.rs
+++ b/src/pre_processor.rs
@@ -1,8 +1,8 @@
+use logos::Span;
 use rustc_hash::{
     FxHashMap,
     FxHashSet,
 };
-use logos::Span;
 
 use crate::{
     diagnostic::{
@@ -259,7 +259,7 @@ impl<'a> PreProcessor<'a, '_> {
             return Ok(false);
         }
 
-        let (_, args) = self.parse_macro_call_args(span)?;
+        let (_, mut args) = self.parse_macro_call_args(span)?;
 
         let arity = args.len();
         let Some((function_define_params, function_define_body)) = overloads.get(&arity).cloned()
@@ -272,6 +272,14 @@ impl<'a> PreProcessor<'a, '_> {
                 span: macro_name_span,
             });
         };
+
+        // Expand used arguments before suppressing this macro in its replacement body.
+        for (param, arg) in function_define_params.iter().zip(&mut args) {
+            if function_define_body.contains(param) {
+                *arg =
+                    self.expand_token_list(std::mem::take(arg), suppress, macro_name_span.clone())?;
+            }
+        }
 
         let mut i = *self.i;
         for token in function_define_body {
@@ -442,9 +450,12 @@ impl<'a> PreProcessor<'a, '_> {
         &mut self,
         tokens: Vec<Token>,
         suppress: &FxHashSet<SmolStr>,
+        source_span: Span,
     ) -> Result<Vec<Token>, Diagnostic> {
-        let mut spanned: Vec<SpannedToken> =
-            tokens.into_iter().map(|token| (0, token, 0)).collect();
+        let mut spanned: Vec<SpannedToken> = tokens
+            .into_iter()
+            .map(|token| (source_span.start, token, source_span.end))
+            .collect();
 
         let length = spanned.len();
 
@@ -597,8 +608,8 @@ impl<'a> PreProcessor<'a, '_> {
             });
         }
 
-        let left = self.expand_token_list(args[0].clone(), suppress)?;
-        let right = self.expand_token_list(args[1].clone(), suppress)?;
+        let left = self.expand_token_list(args[0].clone(), suppress, macro_name_span.clone())?;
+        let right = self.expand_token_list(args[1].clone(), suppress, macro_name_span.clone())?;
 
         let [left] = &left[..] else {
             return Err(Diagnostic {


### PR DESCRIPTION
Nested calls such as `ADD10(ADD10(4))` leave the inner macro unexpanded and fail with `unrecognized function`. Expand referenced arguments before suppressing the outer macro in its replacement body, while preserving recursion suppression and leaving unused arguments unexpanded. Report argument-expansion errors at the macro call site.

Validated with `cargo check --offline`, `cargo test --offline` (12 tests), and formatting checks for the changed file. On macOS, both reported examples compile and emit `say 14` and `say 24`; all 12 existing fixture projects also compile. CLI validation used `std = "0.0.0"` to avoid an unrelated sandbox network-initialization panic.
