### PR TITLE
fix: prevent EOF diagnostic panic without trailing newline

### DIFF
--- a/src/diagnostic/sprite_diagnostics.rs
+++ b/src/diagnostic/sprite_diagnostics.rs
@@ -25,17 +25,17 @@ use serde::{
 use tsify::Tsify;
 
 use super::{
-    diagnostic_kind::DiagnosticKind,
     Diagnostic,
+    diagnostic_kind::DiagnosticKind,
 };
 use crate::{
     ast::Project,
     codegen::debug_info::DebugInfo,
     standard_library::StandardLibrary,
     translation_unit::{
-        parse_translation_unit,
         Owner,
         TranslationUnit,
+        parse_translation_unit,
     },
     vfs::VFS,
 };
@@ -100,7 +100,10 @@ impl SpriteDiagnostics {
                 continue;
             }
             // TODO: memoize this using a memoization crate.
-            let text = fs::read_to_string(&include.path).unwrap();
+            let mut text = fs::read_to_string(&include.path).unwrap();
+            if !text.ends_with('\n') {
+                text.push('\n');
+            }
             let include_path = include
                 .path
                 .strip_prefix(cwd)


### PR DESCRIPTION
Files ending in an incomplete statement without a trailing newline, such as `var myvar`, panic while rendering the EOF diagnostic. Translation units append a synthetic newline, but the diagnostic renderer previously read the shorter original source.

Apply the same trailing-newline normalization to diagnostic snippets so the error span remains in bounds. The source file is unchanged. This also handles included files and missing-include diagnostics without a final newline.

Validated on macOS with 13 CLI cases, including both reported reproducers, included files, CRLF, Unicode strings, and valid input. Both reproducers now report an EOF error and exit with code 1. All 12 existing tests and `cargo check --offline` pass. CLI checks used `std = "0.0.0"` to avoid unrelated network initialization.
